### PR TITLE
Initial IBR Proto

### DIFF
--- a/ibr/ibr.proto
+++ b/ibr/ibr.proto
@@ -52,7 +52,7 @@ message InternalBuildingRepresentation {
   // e.g. "<x> <y>,<x> <y>,<x> <y>"
   // Visualization and other layers index into CoordinatesLookup to determine coordinate segments.
   message CoordinatesLookup {
-    bytesgi encoded_data = 1;
+    bytes encoded_data = 1;
   }
 
   // A representation of the layer in coordinate indices.


### PR DESCRIPTION
The initial partial ibr definition proto.

next steps:
- convert coordinate indices to start/end format
- convert triGrossAreaLayer from Visualization to custom FloorBoundary message (implying floor outline is required on all floors, whereas visualization layers are not standardized and can contain anything optional)