### PR TITLE
Fix windows-latest filepath test errors

### DIFF
--- a/.github/workflows/python_tools.yml
+++ b/.github/workflows/python_tools.yml
@@ -36,7 +36,6 @@ jobs:
         python setup.py install
       working-directory: ./tools/validators/ontology_validator
     - name: Ontology Yaml Validator Generator Tests 
-      if: (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') 
       run: |
        python -m unittest discover -p '*_test.py' --failfast -v
       working-directory: ./tools/validators/ontology_validator/yamlformat/tests

--- a/tools/validators/ontology_validator/yamlformat/tests/entity_type_lib_test.py
+++ b/tools/validators/ontology_validator/yamlformat/tests/entity_type_lib_test.py
@@ -137,7 +137,7 @@ class EntityTypeLibTest(absltest.TestCase):
     type_folder = entity_type_lib.EntityTypeFolder(folderpath)
     self.assertFalse(type_folder.GetFindings())
 
-    good_filepath = folderpath + '/mammal.yaml'
+    good_filepath = os.path.normpath(os.path.join(folderpath, 'mammal.yaml'))
     # Build test proto
     yaml_doc = {
         'cat': {
@@ -158,7 +158,7 @@ class EntityTypeLibTest(absltest.TestCase):
     type_folder = entity_type_lib.EntityTypeFolder(folderpath)
     self.assertFalse(type_folder.GetFindings())
 
-    good_filepath = folderpath + '/mammal.yaml'
+    good_filepath = os.path.normpath(os.path.join(folderpath, 'mammal.yaml'))
     # Build test proto
     yaml_doc = {
         'cat': {

--- a/tools/validators/ontology_validator/yamlformat/tests/entity_type_lib_test.py
+++ b/tools/validators/ontology_validator/yamlformat/tests/entity_type_lib_test.py
@@ -137,7 +137,7 @@ class EntityTypeLibTest(absltest.TestCase):
     type_folder = entity_type_lib.EntityTypeFolder(folderpath)
     self.assertFalse(type_folder.GetFindings())
 
-    good_filepath = os.path.join(folderpath, 'mammal.yaml')
+    good_filepath = folderpath + '/mammal.yaml'
     # Build test proto
     yaml_doc = {
         'cat': {
@@ -158,7 +158,7 @@ class EntityTypeLibTest(absltest.TestCase):
     type_folder = entity_type_lib.EntityTypeFolder(folderpath)
     self.assertFalse(type_folder.GetFindings())
 
-    good_filepath = os.path.join(folderpath, 'mammal.yaml')
+    good_filepath = folderpath + '/mammal.yaml'
     # Build test proto
     yaml_doc = {
         'cat': {


### PR DESCRIPTION
In windows-latest tests, fix

- testAddFromConfigExtraKeys
- testAddFromConfig

The tests were failing because using `os.path.join` introduces inconsistent slashes to the filepath, such as `a/b\c`.

Unfortunately, testcases which were earlier blocked by these two failing tests now have the chance to fail.