### PR TITLE
integrate eslint for auto-linting

### DIFF
--- a/ibr/.eslintrc.json
+++ b/ibr/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+    "env": {
+        "browser": true,
+        "es2020": true
+    },
+    "extends": [
+        "google"
+    ],
+    "parserOptions": {
+        "ecmaVersion": 11,
+        "sourceType": "module"
+    },
+    "rules": {
+    }
+}

--- a/ibr/binToJs.js
+++ b/ibr/binToJs.js
@@ -3,48 +3,49 @@
  * @author shuanglihtk@google.com (Shuang Li)
  */
 
-import { OrbitControls } from './node_modules/three/examples/jsm/controls/OrbitControls.js';
+import {OrbitControls} from './node_modules/three/examples/jsm/controls/OrbitControls.js';
 
 function onChooseFile() {
-    if (typeof window.FileReader !== 'function')
-        throw ("The file API isn't supported on this browser.");
-    let file = document.getElementById("fileForUpload").files[0];
-    if (file) {
-        let fr = new FileReader();
-        fr.onload = function (evt) {
-            var ibrData = evt.target.result;
-            var scene = new THREE.Scene();
-            var camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 10000 );
-            var renderer = new THREE.WebGLRenderer();
-            renderer.setSize( window.innerWidth, window.innerHeight );
-            document.body.appendChild( renderer.domElement );
-            var controls = new OrbitControls( camera, renderer.domElement );
-            controls.target.set( 0, 0.5, 0 );
-            controls.update();
-            controls.enablePan = false;
-            controls.enableDamping = true;
-            var structures = IBRSDK.unpackStructure( ibrData );
-            var layers = [];
-            for ( const structure of structures ) {
-                layers.push( IBRSDK.renderLayer (structure) );
-            }
-            for ( const layer of layers ) {
-                for ( const line of layer ) {
-                    scene.add( line );
-                }
-            }
-            camera.position.set( 0, 0, 7000 );
-            camera.lookAt( 0, 0, 0 );
-            animate();
-
-            // Rendering the scene
-            function animate() {
-                requestAnimationFrame( animate );
-                controls.update();
-                renderer.render( scene, camera );
-            }
+  if (typeof window.FileReader !== 'function') {
+    throw ('The file API isn\'t supported on this browser.');
+  }
+  const file = document.getElementById('fileForUpload').files[0];
+  if (file) {
+    const fr = new FileReader();
+    fr.onload = function(evt) {
+      const ibrData = evt.target.result;
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 10000 );
+      const renderer = new THREE.WebGLRenderer();
+      renderer.setSize( window.innerWidth, window.innerHeight );
+      document.body.appendChild( renderer.domElement );
+      const controls = new OrbitControls( camera, renderer.domElement );
+      controls.target.set( 0, 0.5, 0 );
+      controls.update();
+      controls.enablePan = false;
+      controls.enableDamping = true;
+      const structures = IBRSDK.unpackStructure( ibrData );
+      const layers = [];
+      for ( const structure of structures ) {
+        layers.push( IBRSDK.renderLayer(structure) );
+      }
+      for ( const layer of layers ) {
+        for ( const line of layer ) {
+          scene.add( line );
         }
-        fr.readAsArrayBuffer(file);
-    }
+      }
+      camera.position.set( 0, 0, 7000 );
+      camera.lookAt( 0, 0, 0 );
+      animate();
+
+      // Rendering the scene
+      function animate() {
+        requestAnimationFrame( animate );
+        controls.update();
+        renderer.render( scene, camera );
+      }
+    };
+    fr.readAsArrayBuffer(file);
+  }
 }
 document.getElementById('fileForUpload').addEventListener('change', onChooseFile);

--- a/ibr/package.json
+++ b/ibr/package.json
@@ -12,5 +12,9 @@
     "type": "git",
     "url": "https://github.com/google/digitalbuildings.git"
   },
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "devDependencies": {
+    "eslint": "^7.3.1",
+    "eslint-config-google": "^0.14.0"
+  }
 }


### PR DESCRIPTION
leverages eslint to keep consistent javascript style 

TODO
- document/set up command to autolint before push
- some errors are not auto-fixing

```
realkevinwang@realkevinwang-macbookpro:~/Desktop/digitalbuildings/ibr$ npx eslint binToJs.js --fix

/Users/realkevinwang/Desktop/digitalbuildings/ibr/binToJs.js
   2:1  error  This line has a length of 141. Maximum allowed is 80  max-len
   6:1  error  This line has a length of 90. Maximum allowed is 80   max-len
   8:1  error  Missing JSDoc comment                                 require-jsdoc
  10:5  error  Expected an error object to be thrown                 no-throw-literal
  18:1  error  This line has a length of 107. Maximum allowed is 80  max-len
  42:7  error  Missing JSDoc comment                                 require-jsdoc
  51:1  error  This line has a length of 82. Maximum allowed is 80   max-len

✖ 7 problems (7 errors, 0 warnings)
```