### PR TITLE
IBR UI demo path correction, README directory correction, metadata spelling tweak

### DIFF
--- a/ibr/examples/html/index.html
+++ b/ibr/examples/html/index.html
@@ -10,8 +10,8 @@
         <script src="https://unpkg.com/three@0.118.3/build/three.js"></script>
         <script src="https://unpkg.com/earcut@2.2.2/dist/earcut.min.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/gasparesganga-jquery-loading-overlay@2.1.7/dist/loadingoverlay.min.js"></script>
-		<script src="../../ibr-sdk/temp/ibr_pb_browser.js"></script>
-        <script src="../../ibr-sdk/dist/main.js"></script>
+		<script src="../../ibr_sdk/temp/ibr_pb_browser.js"></script>
+        <script src="../../ibr_sdk/dist/main.js"></script>
         <link href="index.css" rel="stylesheet">
         <link href="slider.css" rel="stylesheet">
     </head>

--- a/ibr/ibr_sdk/README.md
+++ b/ibr/ibr_sdk/README.md
@@ -8,12 +8,12 @@ This purpose of this project is to allow developers to seemlessly work with CAD-
 
 ```
 cd digitalbuildings/ibr/ibr-sdk
-`npm run build
+npm run build
 ```
 
 2. Start a local server in python
 
-`cd ..; python3 -m http.server`.
+`cd ../ python3 -m http.server`.
 
 3. Navigate to http://0.0.0.0:8000/examples/html/
 

--- a/ontology/yaml/resources/HVAC/entity_types/GENERALTYPES.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/GENERALTYPES.yaml
@@ -296,3 +296,17 @@ HWSRSR:
   is_abstract: true
   implements:
   - RSR
+
+CRAC:
+  id: ""
+  description: "A computer room air handler, typically consisting of a constant volume fan and DX coil to maintain cold aisle temperature."
+  is_abstract: true
+  implements:
+  - EQUIPMENT
+
+  CRAH:
+  id: ""
+  description: "A computer room air handler, typically consisting of a VFD to maintain static pressure under floor or in duct as well as a chilled water coil to maintain cold aisle temperature."
+  is_abstract: true
+  implements:
+  - EQUIPMENT

--- a/ontology/yaml/resources/fields/metadata_fields.yaml
+++ b/ontology/yaml/resources/fields/metadata_fields.yaml
@@ -15,7 +15,7 @@
 ## Metadata Field Definitions
 
 literals:
-# Labels: names and manufacturfer codes only
+# Labels: names and manufacturer codes only
 - manufacturer_label
 - model_label
 - zone_use_label # Indicates the type of zone (e.g. lab, office, etc.)


### PR DESCRIPTION
Minor tweaks to IBR:
- script paths in demo index.html were still syntaxed as ibr-sdk instead of the updated ibr_sdk (dash to underscore)
- removed backquote from npm syntax on IBR UI README
- changed _cd ..;_ to _cd ../_ on IBR UI README
- (^^ users can now run IBR Demo locally and experiment with three.js environment for SVL TC2)
- revised spelling to correct _manufacturer_ on metadata_fields.yaml
- (hopefully) set git config appropriately such that Googlebot finds match in CLA and will be happy (good bot)