### PR TITLE
Allow instance_validator.py to support (nested) directory inputs

### DIFF
--- a/tools/validators/instance_validator/instance_validator.py
+++ b/tools/validators/instance_validator/instance_validator.py
@@ -43,16 +43,25 @@ def _ParseArgs() -> argparse.ArgumentParser:
     ArgumentParser object
   """
   parser = argparse.ArgumentParser(
-      description='Validate a YAML building configuration file')
+      description='Validate YAML building configuration files')
 
   parser.add_argument(
       '-i',
       '--input',
       action='append',
       dest='filenames',
-      required=True,
-      help='Filepaths to YAML building configurations',
+      required=False,
+      help='Local path to a YAML building configuration file. May be used multiple times.',
       metavar='FILE')
+
+  parser.add_argument(
+    '-d',
+    '--dir-input',
+    action='append',
+    dest='directories',
+    required=False,
+    help='Local path to a directory (folder) containing YAML building configuration files. May be used multiple times.',
+    metavar='DIR')
 
   parser.add_argument(
       '-m',
@@ -101,6 +110,6 @@ def _ParseArgs() -> argparse.ArgumentParser:
 
 if __name__ == '__main__':
   args = _ParseArgs().parse_args(sys.argv[1:])
-  handler.RunValidation(args.filenames, args.modified_types_filepath,
+  handler.RunValidation(args.filenames, args.directories, args.modified_types_filepath,
                         args.subscription, args.service_account,
                         args.report_filename, int(args.timeout))

--- a/tools/validators/instance_validator/validate/handler.py
+++ b/tools/validators/instance_validator/validate/handler.py
@@ -68,7 +68,7 @@ def _ValidateConfig(
     filenames: List[str],
     universe: pvt.ConfigUniverse) -> List[entity_instance.EntityInstance]:
   """Runs all config validation checks."""
-  print('Loading config files...\n')
+  print('Found {} YAML config files...\n'.format(len(filenames)))
   entities, config_mode = Deserialize(filenames)
   helper = EntityHelper(universe)
   return helper.Validate(entities, config_mode)

--- a/tools/validators/instance_validator/validate/handler.py
+++ b/tools/validators/instance_validator/validate/handler.py
@@ -59,7 +59,7 @@ def Deserialize(
       entities[entity_name] = entity_instance.EntityInstance.FromYaml(
           entity_yaml, default_entity_operation)
     except ValueError:
-      print('Invalid Entity ' + entity_name)
+      print("Invalid Entity '{}'".format(entity_name))
       raise
   return entities, parser.GetConfigMode()
 
@@ -68,7 +68,7 @@ def _ValidateConfig(
     filenames: List[str],
     universe: pvt.ConfigUniverse) -> List[entity_instance.EntityInstance]:
   """Runs all config validation checks."""
-  print('Found {} YAML config files...\n'.format(len(filenames)))
+  print('Found {} YAML config files...'.format(len(filenames)))
   entities, config_mode = Deserialize(filenames)
   helper = EntityHelper(universe)
   return helper.Validate(entities, config_mode)
@@ -238,7 +238,7 @@ class EntityHelper(object):
     Raises:
       SyntaxError: If no building is found in the config
     """
-    print('Validating entities ...')
+    print('\nValidating entities...')
     building_found = False
     valid_entities = {}
     validator = entity_instance.CombinationValidator(self.universe, config_mode,
@@ -248,7 +248,7 @@ class EntityHelper(object):
           and current_entity.type_name.lower() == 'building'):
         building_found = True
       if not validator.Validate(current_entity):
-        print(entity_name, 'is not a valid instance')
+        print("Invalid instance: {}".format(entity_name))
         continue
       valid_entities[entity_name] = current_entity
 

--- a/tools/validators/instance_validator/validate/handler.py
+++ b/tools/validators/instance_validator/validate/handler.py
@@ -42,7 +42,7 @@ def Deserialize(
   parser = instance_parser.InstanceParser()
   for idx, yaml_file in enumerate(yaml_files):
     file_number = idx + 1
-    print("[#{}] Queueing '{}'".format(file_number, yaml_file))
+    print("[#{}] Queuing '{}'".format(file_number, yaml_file))
     # Once the file is added to the queue the parser will asynchronously
     # get around to actually parsing it-- include a trackable file_number
     # for easier / more useful printed output later...
@@ -113,7 +113,8 @@ def RunValidation(filenames: List[str], directories: List[str],
     for directory in directories:
       for root, dirs, files in os.walk(directory):
         for file in files:
-          if file.lower().endswith('.yaml'):
+          _lowername = file.lower()
+          if _lowername.endswith('.yaml') or _lowername.endswith('.yml'):
             filenames.append(os.path.join(root, file))
 
   entities = _ValidateConfig(filenames, universe)

--- a/tools/validators/instance_validator/validate/instance_parser.py
+++ b/tools/validators/instance_validator/validate/instance_parser.py
@@ -15,7 +15,6 @@
 from __future__ import print_function
 
 import collections
-import copy
 import enum
 import re
 import sys
@@ -271,7 +270,7 @@ class InstanceParser():
 
         if _CONFIG_METADATA_PATTERN.match(line):
           if self._config_mode:
-            _msg = "\n[#{}] Validation Error in '{}':\n{}: '{}'\n"
+            _msg = "\n[#{}] ERROR in '{}':\n{}: '{}'\n"
             print(_msg.format(
               entity_instance_block['source_filenumber'],
               entity_instance_block['source_filename'],
@@ -409,7 +408,7 @@ class InstanceParser():
             syaml.exceptions.YAMLValidationError,
             syaml.exceptions.DuplicateKeysDisallowed,
             syaml.exceptions.InconsistentIndentationDisallowed) as exception:
-      _msg = "\n[#{}] Validation Error in '{}':\n{}\n"
+      _msg = "\n[#{}] ERROR in '{}':\n{}\n"
       print(_msg.format(
         unvalidated_block['source_filenumber'],
         unvalidated_block['source_filename'],


### PR DESCRIPTION
This PR aims to address issue #177 while also making minor improvements to the printed output from the tools/validators/instance_validator/instance_validator.py script to make the output easier to read and understand. Specifically, this PR:

- Adds support for passing in directory paths (using -d or --dir).
- Directory paths are recursively scanned for *.yaml, *.YAML, *.yml, or *.YML files to parse.
- Adds a printout of the total number of yaml files found from all passed-in file and directory paths.
- Prints an incremental list of the yaml file queuing and parsing status as it happens.
- On any validation error or exception it prints exactly which file triggered the error.
- Cleans up / aligns some of the error messages and other script output.


### Example Outputs

**Run with 1 directory input with no config file validation errors**

```
$ python instance_validator.py -d tests/fake_instances/multi/

Starting universe generation...

Starting config validation...

Found 5 YAML config files...
[#1] Queuing 'tests/fake_instances/multi/good_with_metadata_at_end.yaml'
[#2] Queuing 'tests/fake_instances/multi/good_building_connections.yaml'
[#3] Queuing 'tests/fake_instances/multi/good_building_type.yaml'
[#4] Queuing 'tests/fake_instances/multi/good_with_metadata.yaml'
[#5] Queuing 'tests/fake_instances/multi/good_links.yaml'
[#1] Validating 'tests/fake_instances/multi/good_with_metadata_at_end.yaml'
[#2] Validating 'tests/fake_instances/multi/good_building_connections.yaml'
[#3] Validating 'tests/fake_instances/multi/good_building_type.yaml'
[#4] Validating 'tests/fake_instances/multi/good_with_metadata.yaml'
[#5] Validating 'tests/fake_instances/multi/good_links.yaml'

Validating entities...
Orphan connection to: A-THIRD-ENTITY
Orphan connection to: ANOTHER-ENTITY
Invalid instance: UK-LON-S2
All entities validated
```

**Run with 1 directory input (which has a nested directory) with no config validation errors**

```
$ python instance_validator.py -d tests/fake_instances/multi/

Starting universe generation...

Starting config validation...

Found 6 YAML config files...
[#1] Queuing 'tests/fake_instances/multi/good_with_metadata_at_end.yaml'
[#2] Queuing 'tests/fake_instances/multi/good_building_connections.yaml'
[#3] Queuing 'tests/fake_instances/multi/good_building_type.yaml'
[#4] Queuing 'tests/fake_instances/multi/good_with_metadata.yaml'
[#5] Queuing 'tests/fake_instances/multi/subfolder/good_building_3.yaml'
[#6] Queuing 'tests/fake_instances/multi/subfolder/good_building_2.yaml'
[#1] Validating 'tests/fake_instances/multi/good_with_metadata_at_end.yaml'
[#2] Validating 'tests/fake_instances/multi/good_building_connections.yaml'
[#3] Validating 'tests/fake_instances/multi/good_building_type.yaml'
[#4] Validating 'tests/fake_instances/multi/good_with_metadata.yaml'
[#5] Validating 'tests/fake_instances/multi/subfolder/good_building_3.yaml'
[#6] Validating 'tests/fake_instances/multi/subfolder/good_building_2.yaml'

Validating entities...
Orphan connection to: A-THIRD-ENTITY
Orphan connection to: ANOTHER-ENTITY
Invalid instance: UK-LON-S2
All entities validated
```

**Run with multiple directory inputs with no config validation errors**

```
$ python instance_validator.py -d tests/fake_instances/multi/ -d tests/fake_instances/otherdir/

Starting universe generation...

Starting config validation...

Found 6 YAML config files...
[#1] Queuing 'tests/fake_instances/multi/good_with_metadata_at_end.yaml'
[#2] Queuing 'tests/fake_instances/multi/good_building_connections.yaml'
[#3] Queuing 'tests/fake_instances/multi/good_building_type.yaml'
[#4] Queuing 'tests/fake_instances/multi/good_with_metadata.yaml'
[#5] Queuing 'tests/fake_instances/otherdir/good_building_3.yaml'
[#6] Queuing 'tests/fake_instances/otherdir/good_building_2.yaml'
[#1] Validating 'tests/fake_instances/multi/good_with_metadata_at_end.yaml'
[#2] Validating 'tests/fake_instances/multi/good_building_connections.yaml'
[#3] Validating 'tests/fake_instances/multi/good_building_type.yaml'
[#4] Validating 'tests/fake_instances/multi/good_with_metadata.yaml'
[#5] Validating 'tests/fake_instances/otherdir/good_building_3.yaml'
[#6] Validating 'tests/fake_instances/otherdir/good_building_2.yaml'

Validating entities...
Orphan connection to: A-THIRD-ENTITY
Orphan connection to: ANOTHER-ENTITY
Invalid instance: UK-LON-S2
All entities validated
```

**Run with 1 directory input with duplicate block error**

```
$ python instance_validator.py -d tests/fake_instances/GOOD/

Starting universe generation...

Starting config validation...

Found 18 YAML config files...
[#1] Queuing 'tests/fake_instances/GOOD/good_building_translation_fields.yaml'
[#2] Queuing 'tests/fake_instances/GOOD/good_with_metadata_at_end.yaml'
[#2] Validating 'tests/fake_instances/GOOD/good_with_metadata_at_end.yaml'
[#3] Queuing 'tests/fake_instances/GOOD/good_entity_update.yaml'

[#3] ERROR in 'tests/fake_instances/GOOD/good_entity_update.yaml':
Metadata block defined multiple times or in multiple files: 'CONFIG_METADATA:'
```

**Run with 1 directory input and multiple file inputs with validation errors**

```
$ python instance_validator.py -d tests/fake_instances/multi/ -i tests/fake_instances/GOOD/good_links.yaml -i tests/fake_instances/GOOD/good_with_metadata_at_end.yaml 

Starting universe generation...

Starting config validation...

Found 5 YAML config files...
[#1] Queuing 'tests/fake_instances/GOOD/good_links.yaml'
[#2] Queuing 'tests/fake_instances/GOOD/good_with_metadata_at_end.yaml'
[#2] Validating 'tests/fake_instances/GOOD/good_with_metadata_at_end.yaml'
[#3] Queuing 'tests/fake_instances/multi/good_building_connections.yaml'
[#1] Validating 'tests/fake_instances/GOOD/good_links.yaml'

[#1] ERROR in 'tests/fake_instances/GOOD/good_links.yaml':
while parsing a mapping
  in "<unicode string>", line 1, column 1:
    ENTITY-NAME:
     ^ (line: 1)
required key(s) 'etag' not found
  in "<unicode string>", line 9, column 1:
          differential_pressure_spec ... 
    ^ (line: 9)
```