### PR TITLE
New AHU type for ML Pilot

### DIFF
--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -2853,7 +2853,7 @@ AHU_CHWDT_CHWVM_CLPM_OAFM_STC_SFSS_UV_CO2C:
   - supply_fan_lost_power_alarm
   - control_status
   
- AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X:
+AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X:
   description: "Multi-zone AHU with refrigeration monitoring and supply air temperature and pressure control."
   is_canonical: true
   implements:
@@ -2879,7 +2879,7 @@ AHU_BSPC_DX4SC_ECONM_EDPM_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_SSPCSCM_STCSCM:
   - SSPCSCM
   - STCSCM
   
- AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X_SSPCSCM_STCSCM:
+AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X_SSPCSCM_STCSCM:
   description: "Multi-zone AHU with refrigeration monitoring and supply air temperature and pressure control with supervisor contron mode types (machine learning)."
   is_canonical: true
   implements:

--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -2854,7 +2854,6 @@ AHU_CHWDT_CHWVM_CLPM_OAFM_STC_SFSS_UV_CO2C:
   - control_status
   
  AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X:
-  id: ""
   description: "Multi-zone AHU with refrigeration monitoring and supply air temperature and pressure control."
   is_canonical: true
   implements:
@@ -2870,7 +2869,6 @@ AHU_CHWDT_CHWVM_CLPM_OAFM_STC_SFSS_UV_CO2C:
   - STC
   - REFSM2X
   - REFPM2X
-  
 
 AHU_BSPC_DX4SC_ECONM_EDPM_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_SSPCSCM_STCSCM:
   id: "11591053366720987136"
@@ -2882,14 +2880,12 @@ AHU_BSPC_DX4SC_ECONM_EDPM_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_SSPCSCM_STCSCM:
   - STCSCM
   
   AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X_SSPCSCM_STCSCM:
-  id: ""
   description: "Multi-zone AHU with refrigeration monitoring and supply air temperature and pressure control with supervisor contron mode types (machine learning)."
   is_canonical: true
   implements:
   - AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X
   - SSPCSCM
   - STCSCM
-
 
 ###################################
 ### Existing Non-standard Types ###

--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -2879,7 +2879,7 @@ AHU_BSPC_DX4SC_ECONM_EDPM_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_SSPCSCM_STCSCM:
   - SSPCSCM
   - STCSCM
   
-  AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X_SSPCSCM_STCSCM:
+ AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X_SSPCSCM_STCSCM:
   description: "Multi-zone AHU with refrigeration monitoring and supply air temperature and pressure control with supervisor contron mode types (machine learning)."
   is_canonical: true
   implements:

--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -2852,6 +2852,25 @@ AHU_CHWDT_CHWVM_CLPM_OAFM_STC_SFSS_UV_CO2C:
   - smoke_alarm
   - supply_fan_lost_power_alarm
   - control_status
+  
+ AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X:
+  id: ""
+  description: "Multi-zone AHU with refrigeration monitoring and supply air temperature and pressure control."
+  is_canonical: true
+  implements:
+  - AHU
+  - BSPC
+  - DX3SC
+  - ECON
+  - EFSS
+  - EFVSC
+  - SFSS
+  - SFVSC
+  - SSPC
+  - STC
+  - REFSM2X
+  - REFPM2X
+  
 
 AHU_BSPC_DX4SC_ECONM_EDPM_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_SSPCSCM_STCSCM:
   id: "11591053366720987136"
@@ -2859,6 +2878,15 @@ AHU_BSPC_DX4SC_ECONM_EDPM_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_SSPCSCM_STCSCM:
   is_canonical: true
   implements:
   - AHU_BSPC_DX4SC_ECONM_EDPM_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC
+  - SSPCSCM
+  - STCSCM
+  
+  AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X_SSPCSCM_STCSCM:
+  id: ""
+  description: "Multi-zone AHU with refrigeration monitoring and supply air temperature and pressure control with supervisor contron mode types (machine learning)."
+  is_canonical: true
+  implements:
+  - AHU_BSPC_DX3SC_ECON_EFSS_EFVSC_SFSS_SFVSC_SSPC_STC_REFSM2X_REFPM2X
   - SSPCSCM
   - STCSCM
 


### PR DESCRIPTION
New AHU type that integrates refrigeration circuit monitoring subtypes.  Added canonical types with and without supervisory control subtypes (for ML Pilot). @tasodorff