### PR TITLE
Add 1:many mapping of multistate values

### DIFF
--- a/tools/validators/instance_validator/tests/entity_instance_test.py
+++ b/tools/validators/instance_validator/tests/entity_instance_test.py
@@ -298,6 +298,27 @@ class EntityInstanceTest(absltest.TestCase):
 
     self.assertFalse(self.init_validator.Validate(instance))
 
+  def testValidateGoodTranslationStatesList(self):
+    parsed = _Helper(
+      [path.join(_TESTCASE_PATH, 'GOOD', 'good_translation_states_list.yaml')])
+    parsed = dict(parsed)
+    entity = dict(parsed[list(parsed)[0]])
+
+    instance = entity_instance.EntityInstance.FromYaml(entity)
+
+    self.assertTrue(self.init_validator.Validate(instance))
+
+  def testValidateBadTranslationStatesListWithDuplicate(self):
+    parsed = _Helper(
+      [path.join(_TESTCASE_PATH, 'BAD',
+                 'bad_translation_states_list_with_duplicate.yaml')])
+    parsed = dict(parsed)
+    entity = dict(parsed[list(parsed)[0]])
+
+    instance = entity_instance.EntityInstance.FromYaml(entity)
+
+    self.assertFalse(self.init_validator.Validate(instance))
+
   def testValidateBadLinkFields(self):
     parsed = _Helper(
         [path.join(_TESTCASE_PATH, 'BAD', 'bad_building_links_fields.yaml')])

--- a/tools/validators/instance_validator/tests/fake_instances/BAD/bad_translation_states_list_with_duplicate.yaml
+++ b/tools/validators/instance_validator/tests/fake_instances/BAD/bad_translation_states_list_with_duplicate.yaml
@@ -1,0 +1,35 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DMP_EDM-17:
+  type: HVAC/DMP_EDM
+  id: CDM/123456
+  cloud_device_id: "foobar"
+  translation:
+    exhaust_air_damper_command:
+      present_value: "points.exhaust_air_damper_command.present_value"
+      states:
+        OPEN: "1"
+        CLOSED: "0"
+    exhaust_air_damper_status:
+      present_value: "points.exhaust_air_damper_status.present_value"
+      states:
+        OPEN:
+        - "1"
+        - "2"
+        CLOSED: "1"
+
+UK-LON-S2:
+  type: FACILITIES/BUILDING
+  id: FACILITIES/123456

--- a/tools/validators/instance_validator/tests/fake_instances/BAD/bad_translation_states_list_with_duplicate.yaml
+++ b/tools/validators/instance_validator/tests/fake_instances/BAD/bad_translation_states_list_with_duplicate.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This config file is invalid because the telemetry value "1" is mapped to
+# both OPEN and CLOSED states of exhaust_air_damper_status.
+
 DMP_EDM-17:
   type: HVAC/DMP_EDM
   id: CDM/123456

--- a/tools/validators/instance_validator/tests/fake_instances/GOOD/good_translation_states_list.yaml
+++ b/tools/validators/instance_validator/tests/fake_instances/GOOD/good_translation_states_list.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DMP_EDM-17:
+  type: HVAC/DMP_EDM
+  id: CDM/123456
+  cloud_device_id: "foobar"
+  translation:
+    exhaust_air_damper_command:
+      present_value: "points.exhaust_air_damper_command.present_value"
+      states:
+        OPEN:
+        - "1"
+        - "2"
+        CLOSED:
+        - "0"
+        - "3"
+    exhaust_air_damper_status:
+      present_value: "points.exhaust_air_damper_status.present_value"
+      states:
+        OPEN:
+        - "1"
+        - "2"
+        CLOSED: "0"
+
+UK-LON-S2:
+  type: FACILITIES/BUILDING
+  id: FACILITIES/123456

--- a/tools/validators/instance_validator/tests/fake_telemetry/telemetry_good_states_list.json
+++ b/tools/validators/instance_validator/tests/fake_telemetry/telemetry_good_states_list.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2020-10-15T17:21:59.000Z",
+  "version": 1,
+  "points": {
+    "exhaust_air_damper_command": {
+      "present_value": 1
+    },
+    "exhaust_air_damper_status": {
+      "present_value": 1
+    }
+  }
+}

--- a/tools/validators/instance_validator/tests/telemetry_validator_test.py
+++ b/tools/validators/instance_validator/tests/telemetry_validator_test.py
@@ -106,11 +106,16 @@ with open(
     encoding='utf-8') as file:
   _MESSAGE_MULTIPLE_ERRORS = FakeMessage(_MESSAGE_ATTRIBUTES_1, file.read())
 
-  with open(
-      path.join(_TELEMETRY_PATH, 'telemetry_good_multistates.json'),
-      encoding='utf-8') as file:
-    _MESSAGE_GOOD_MULTIPLE_STATES = FakeMessage(_MESSAGE_ATTRIBUTES_4,
-                                                file.read())
+with open(
+    path.join(_TELEMETRY_PATH, 'telemetry_good_multistates.json'),
+    encoding='utf-8') as file:
+  _MESSAGE_GOOD_MULTIPLE_STATES = FakeMessage(_MESSAGE_ATTRIBUTES_4,
+                                              file.read())
+
+with open(
+    path.join(_TELEMETRY_PATH, 'telemetry_good_states_list.json'),
+    encoding='utf-8') as file:
+  _MESSAGE_GOOD_STATES_LIST = FakeMessage(_MESSAGE_ATTRIBUTES_2, file.read())
 
 # TODO: fix inconsistency between telemetry parser expecting a string,
 # but instance parser expecting a file
@@ -143,6 +148,10 @@ _ENTITY_NAME_4 = 'SDC_EXT-18'
 # A test entity to make sure that booleans are retrieved and validated.
 _ENTITIES_5 = _CreateEntityInstances('good_translation_multi_states.yaml')
 _ENTITY_NAME_5 = 'FAN-17'
+
+# A test entity with a field that maps multiple raw values to one state.
+_ENTITIES_6 = _CreateEntityInstances('good_translation_states_list.yaml')
+_ENTITY_NAME_6 = 'DMP_EDM-17'
 
 _POINT_NAME_1 = 'points.return_water_temperature_sensor.present_value'
 _POINT_NAME_2 = 'points.supply_water_temperature_sensor.present_value'
@@ -309,6 +318,17 @@ class TelemetryValidatorTest(absltest.TestCase):
                                                        ValidationCallback)
 
     validator.ValidateMessage(_MESSAGE_GOOD_MULTIPLE_STATES)
+
+  def testTelemetryValidatorOnMultiStateWithRawValueList(self):
+
+    def ValidationCallback(validator):
+      self.assertEmpty(validator.GetErrors())
+      self.assertTrue(validator.AllEntitiesValidated())
+
+    validator = telemetry_validator.TelemetryValidator(_ENTITIES_6, 1,
+                                                       ValidationCallback)
+
+    validator.ValidateMessage(_MESSAGE_GOOD_STATES_LIST)
 
 
 if __name__ == '__main__':

--- a/tools/validators/instance_validator/validate/entity_instance.py
+++ b/tools/validators/instance_validator/validate/entity_instance.py
@@ -365,7 +365,8 @@ class InstanceValidator(object):
       raw_values_found = set()
       for state, value in ft.states.items():
         if state not in valid_states:
-          print(f'Field {qualified_field_name} has an invalid state: {state}')
+          print(f'Field {qualified_field_name} has an invalid state: {state}'
+                f' (expected {", ".join(valid_states)})')
           is_valid = False
         raw_values = value if isinstance(value, list) else [value]
         for raw_value in raw_values:

--- a/tools/validators/instance_validator/validate/entity_instance.py
+++ b/tools/validators/instance_validator/validate/entity_instance.py
@@ -362,10 +362,19 @@ class InstanceValidator(object):
         return False
 
       is_valid = True
-      for state in ft.states.keys():
+      raw_values_found = set()
+      for state, value in ft.states.items():
         if state not in valid_states:
           print(f'Field {qualified_field_name} has an invalid state: {state}')
           is_valid = False
+        raw_values = value if isinstance(value, list) else [value]
+        for raw_value in raw_values:
+          if raw_value in raw_values_found:
+            print(f'Raw value {raw_value} is assigned to multiple states for '
+                  f'{qualified_field_name}')
+            is_valid = False
+          raw_values_found.add(raw_value)
+
       return is_valid
 
     if isinstance(ft, ft_lib.MultiStateValue):

--- a/tools/validators/instance_validator/validate/entity_instance.py
+++ b/tools/validators/instance_validator/validate/entity_instance.py
@@ -362,7 +362,6 @@ class InstanceValidator(object):
         return False
 
       is_valid = True
-      raw_values_found = set()
       for state, value in ft.states.items():
         if state not in valid_states:
           print(f'Field {qualified_field_name} has an invalid state: {state}'
@@ -370,11 +369,11 @@ class InstanceValidator(object):
           is_valid = False
         raw_values = value if isinstance(value, list) else [value]
         for raw_value in raw_values:
-          if raw_value in raw_values_found:
-            print(f'Raw value {raw_value} is assigned to multiple states for '
-                  f'{qualified_field_name}')
+          if ft.raw_values[raw_value] != state:
+            print(f'Field {qualified_field_name} has raw value {raw_value} '
+                  f'mapped to more than one state: {state} and '
+                  f'{ft.raw_values[raw_value]}')
             is_valid = False
-          raw_values_found.add(raw_value)
 
       return is_valid
 

--- a/tools/validators/instance_validator/validate/field_translation.py
+++ b/tools/validators/instance_validator/validate/field_translation.py
@@ -15,7 +15,7 @@
 
 import enum
 
-from typing import Dict
+from typing import Dict, List, Union
 
 
 class PresenceMode(enum.Enum):
@@ -95,14 +95,21 @@ class MultiStateValue(DefinedField):
     states: Dictionary from standard states to expected telemetry states. States
       should be qualified like fields, as would be required in a valid building
       config file.
+    raw_values: Dictionary from telemetry states to standard states.
   """
 
   def __init__(self, std_field_name: str, raw_field_name: str,
-               states: Dict[str, str]):
+               states: Dict[str, Union[str, List[str]]]):
     super().__init__(std_field_name, raw_field_name)
     if not states:
       raise ValueError('states cannot be empty')
     self.states = states
+    self.raw_values = {}
+    for state, value in states.items():
+      if isinstance(value, list):
+        self.raw_values.update({v: state for v in value})
+      else:
+        self.raw_values[value] = state
 
 
 class DimensionalValue(DefinedField):

--- a/tools/validators/instance_validator/validate/instance_parser.py
+++ b/tools/validators/instance_validator/validate/instance_parser.py
@@ -152,7 +152,10 @@ _TRANSLATION_SCHEMA = syaml.MapPattern(
         PRESENT_VALUE_KEY:
             syaml.Str(),
         syaml.Optional(STATES_KEY):
-            syaml.MapPattern(syaml.Regex(u'^[A-Z][A-Z_]+'), syaml.Str()),
+            syaml.MapPattern(
+                syaml.Regex(u'^[A-Z][A-Z_]+'),
+                syaml.Str() | syaml.Seq(syaml.Str())
+            ),
         syaml.Optional(UNITS_KEY):
             syaml.Map({
                 UNIT_NAME_KEY: syaml.Str(),

--- a/tools/validators/instance_validator/validate/telemetry_validator.py
+++ b/tools/validators/instance_validator/validate/telemetry_validator.py
@@ -154,7 +154,7 @@ class TelemetryValidator(object):
         continue
 
       if isinstance(field_translation, ft_lib.MultiStateValue):
-        if pv not in field_translation.states.values():
+        if pv not in field_translation.raw_values:
           self.AddError(
               telemetry_error.TelemetryError(
                   entity_name, field_translation.raw_field_name,


### PR DESCRIPTION
This patch updates the instance validator to allow any multistate field to have multiple raw values mapped to a single standard state, per issue #349.  This can be represented in the building config by providing a sequence of raw value strings instead of a single string.

This also adds a multistate field validation check that identifies when a raw value has been associated with multiple standard states.