### PR TITLE
New subfields for temporal aggregations

### DIFF
--- a/ontology/yaml/resources/subfields/subfields.yaml
+++ b/ontology/yaml/resources/subfields/subfields.yaml
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+aggregation_descriptor:
+  sensorgroup: "A cohort of physical sensors; must measure the same measurement."
+  timeinterval: "A defined interval of time (e.g. five seconds)."
 aggregation:
   average: "Average value (e.g. average_zone_air_temperature_sensor)"
   max: "Maximum value (e.g. Max_Cooling_Air_Flow_Setpoint)"
   min: "Minimum value (e.g. Min_Ventilation_Air_Flow_Setpoint)"
   total: "Sum total of some set of values (e.g. total_request_heating_count)"
+  rootmeansquare: "Square root of the mean square (quadratic mean); measures the magnitude of a set of values."
 component:
   battery: "A device used to store power for use at a later time (e.g. in an emergency where grid power is unavailable)."
   cable: "A length of wire, sometimes shielded externally, used for some purpose (e.g. steel braided wire for tensile support, CAT5 cable for communications, etc.)."
@@ -146,6 +150,7 @@ descriptor:
   return: "Measurement or process of media as it is returned from the end-use equipment within the system."
   reversing: "Reverses direction of flow (e.g. reversing valve on heat pump)."
   room: "A space that can be occupied, or a part or division of a building or floor enclosed by walls."
+  rootmeansquare: "Square root of the mean square (quadratic mean); measures the magnitude of a set of values."
   scene : "The holistic ambience achieved from coordinated control of an area's lighting levels and colors. One of many stored setpoints that may be recalled to apply predetermined lighting levels across a number of fixtures."
   schedule: "Refers to the time-of-day run-time requirements for the equipment."
   season: "Weather conditions under which certain systems or processes are enabled."
@@ -178,6 +183,9 @@ descriptor:
   west: "Cardinal direction; opposite of east"
   wind: "Movement of ambient air."
   winter: "Method or process used during colder weather (i.e. winter season)."
+  xaxis: "Horizontal axis of a three-dimensional Cartesian coordinate system (abscissa)."
+  yaxis: "Horizontal axis of a three-dimensional Cartesian coordinate system (ordinate)."
+  zaxis: "Vertical axis of a three-dimensional Cartesian coordinate system (applicate)."
   zone: "Region of building which is conditioned."
   #New descriptor subfields for CH ZRH EURD
   conditioning: "Treatment of a medium"


### PR DESCRIPTION
Added a new subfield section "aggregation_descriptor" to help delineate between temporal and spatial aggregations.

New descriptor subfields for measurements within a 3-dimensional Cartesian coordinate system.

@mschulze17 
@tasodorff 