### PR TITLE
Fix telemetry validator not exiting after timeout

### DIFF
--- a/tools/validators/instance_validator/validate/handler.py
+++ b/tools/validators/instance_validator/validate/handler.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 from datetime import datetime
 import sys
+import _thread
 from typing import Callable, Dict, List, Optional
 
 from validate import entity_instance
@@ -189,7 +190,7 @@ class TelemetryHelper(object):
         print('\n')
         print(report)
       print('Report Generated')
-      sys.exit(0)
+      _thread.interrupt_main()
 
     return TelemetryValidationCallback
 

--- a/tools/validators/instance_validator/validate/telemetry_validator.py
+++ b/tools/validators/instance_validator/validate/telemetry_validator.py
@@ -57,7 +57,6 @@ class TelemetryValidator(object):
     self._validation_errors = []
     self._validation_warnings = []
 
-  # TODO(charbull): fix this timeout
   def StartTimer(self):
     """Starts the validation timeout timer."""
     threading.Timer(self.timeout, lambda: self.callback(self)).start()


### PR DESCRIPTION
This patch addresses issue #176, where the instance validator does not exit from telemetry validation after the desired timeout.  sys.exit does not work because it only closes the program when it is called from the main thread.  Instead, _thread.interrupt_main raises a KeyboardInterrupt exception on the main thread, which Subscriber.Listen will catch and then gracefully exit.

I don't have any valid pubsub account credentials, so I have only tested this by replacing the Subscriber.Listen call with an infinite loop that sleeps for short periods and catches KeyboardInterrupt exceptions, which allowed the program to exit when the timeout was reached.  This should be tested with a real subscriber client running, but I believe the threading behavior will be the same.