### PR TITLE
Redesign unit_lib to support measurement aliases.

### DIFF
--- a/ontology/docs/ontology_config.md
+++ b/ontology/docs/ontology_config.md
@@ -287,11 +287,25 @@ One of the listed units must be listed as the `STANDARD` unit for the type. All
 of the `STANDARD` units for all subfields must belong to the same unit family,
 such as standard SI units.
 
+If a subfield needs to use the same set of units as another subfield, it is
+defined as an alias by providing the other subfield name instead of a list of
+units. For example:
+
+```
+distance:
+- meters: STANDARD
+- feet
+- inches
+length: distance
+level: distance
+```
+
 Validation enforces:
 
 *   Each subfield only has units defined for it one time
 *   Each dimensional unit is defined only once in the file
 *   Exactly one `STANDARD` designation is made per subfield
+*   Each subfield alias refers to a subfield that has units defined
 
 ## Validation
 

--- a/tools/validators/ontology_validator/yamlformat/tests/parse_config_lib_test.py
+++ b/tools/validators/ontology_validator/yamlformat/tests/parse_config_lib_test.py
@@ -366,22 +366,25 @@ class ParseConfigLibTest(absltest.TestCase):
     self.assertLen(unit_folders, 2)
     for folder in unit_folders:
       self.assertEmpty(folder.GetFindings())
-      units_map = folder.local_namespace.units
+      current_units = folder.local_namespace.GetUnitsForMeasurement(
+          'current')
+      temperature_units = folder.local_namespace.GetUnitsForMeasurement(
+          'temperature')
       if not folder.local_namespace.namespace:
         # global namespace
-        self.assertEqual(units_map['amperes'],
-                         unit_lib.Unit('amperes', 'current', True))
-        self.assertEqual(units_map['milliamperes'],
-                         unit_lib.Unit('milliamperes', 'current'))
+        self.assertEqual(current_units['amperes'],
+                         unit_lib.Unit('amperes', True))
+        self.assertEqual(current_units['milliamperes'],
+                         unit_lib.Unit('milliamperes'))
       else:
         # local namespace
         self.assertEqual(folder.local_namespace.namespace, 'GOOD')
-        self.assertEqual(units_map['kelvins'],
-                         unit_lib.Unit('kelvins', 'temperature', True))
-        self.assertEqual(units_map['degrees_celsius'],
-                         unit_lib.Unit('degrees_celsius', 'temperature'))
-        self.assertEqual(units_map['degrees_fahrenheit'],
-                         unit_lib.Unit('degrees_fahrenheit', 'temperature'))
+        self.assertEqual(temperature_units['kelvins'],
+                         unit_lib.Unit('kelvins', True))
+        self.assertEqual(temperature_units['degrees_celsius'],
+                         unit_lib.Unit('degrees_celsius'))
+        self.assertEqual(temperature_units['degrees_fahrenheit'],
+                         unit_lib.Unit('degrees_fahrenheit'))
 
   def testParseUnitFoldersFromBadFile(self):
     bad_units = base_lib.PathParts(

--- a/tools/validators/ontology_validator/yamlformat/tests/presubmit_validate_types_lib_test.py
+++ b/tools/validators/ontology_validator/yamlformat/tests/presubmit_validate_types_lib_test.py
@@ -207,8 +207,8 @@ class PresubmitValidateTypesTest(absltest.TestCase):
   def testConfigUniverseGetUnitsForMeasurement(self):
     folder = unit_lib.UnitFolder('units/anyfolder')
     namespace = folder.local_namespace
-    namespace.InsertUnit(unit_lib.Unit('degrees_celsius', 'temperature', False))
-    namespace.InsertUnit(unit_lib.Unit('kelvin', 'temperature', True))
+    namespace.InsertUnit('temperature', unit_lib.Unit('degrees_celsius', False))
+    namespace.InsertUnit('temperature', unit_lib.Unit('kelvin', True))
     unit_universe = unit_lib.UnitUniverse([folder])
 
     config_universe = presubmit_validate_types_lib.ConfigUniverse(

--- a/tools/validators/ontology_validator/yamlformat/tests/unit_lib_test.py
+++ b/tools/validators/ontology_validator/yamlformat/tests/unit_lib_test.py
@@ -241,6 +241,28 @@ class UnitLibTest(absltest.TestCase):
     self.assertIsInstance(folder.local_namespace.GetFindings()[0],
                           findings_lib.MeasurementAliasIsAliasedError)
 
+  def testUnitFolderAddFromConfigDuplicateAlias(self):
+    doc_1 = {
+      'distance': [
+        {'yards': 'STANDARD'},
+        'inches'
+      ],
+      'level': 'distance',
+    }
+    doc_2 = {
+      'length': [
+        {'meters': 'STANDARD'},
+        'feet'
+      ],
+      'level': 'length',
+    }
+    folder = unit_lib.UnitFolder(_GOOD_PATH)
+
+    folder.AddFromConfig([doc_1, doc_2], '{0}/file.yaml'.format(_GOOD_PATH))
+
+    self.assertIsInstance(folder.local_namespace.GetFindings()[0],
+                          findings_lib.DuplicateMeasurementAliasError)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tools/validators/ontology_validator/yamlformat/tests/unit_lib_test.py
+++ b/tools/validators/ontology_validator/yamlformat/tests/unit_lib_test.py
@@ -28,17 +28,17 @@ _GOOD_PATH = '{0}/units/anyfolder'.format('mynamespace')
 
 class UnitLibTest(absltest.TestCase):
 
-  def testUnitUniverseGetUnitsMap(self):
+  def testUnitUniverseGetUnitsForMeasurement(self):
     folder = unit_lib.UnitFolder(_GOOD_PATH)
     namespace = folder.local_namespace
-    namespace.InsertUnit(unit_lib.Unit('degrees_celsius', 'temperature', False))
-    namespace.InsertUnit(unit_lib.Unit('kelvins', 'temperature', True))
+    namespace.InsertUnit('temperature', unit_lib.Unit('degrees_celsius', False))
+    namespace.InsertUnit('temperature', unit_lib.Unit('kelvins', True))
+    namespace.InsertUnit('percent', unit_lib.Unit('percent', True))
     unit_universe = unit_lib.UnitUniverse([folder])
 
-    units = unit_universe.GetUnitsMap('mynamespace')
+    units = unit_universe.GetUnitsForMeasurement('temperature', 'mynamespace')
 
-    self.assertIn('degrees_celsius', units)
-    self.assertIn('kelvins', units)
+    self.assertCountEqual(['degrees_celsius', 'kelvins'], units)
 
   def testUnitUniverseGetFindings(self):
     context = findings_lib.FileContext('{0}/file.yaml'.format(_GOOD_PATH))
@@ -47,10 +47,10 @@ class UnitLibTest(absltest.TestCase):
     namespace = folder.local_namespace
     namespace.AddFinding(
         findings_lib.DuplicateUnitDefinitionError(
-            namespace, unit_lib.Unit('unit', 'measurement'), context))
-    unit = unit_lib.Unit('unit', 'measurement')
+            namespace, unit_lib.Unit('unit'), context))
+    unit = unit_lib.Unit('unit')
     unit.AddFinding(findings_lib.UnknownUnitTagError(unit.name, 'tag', context))
-    namespace.InsertUnit(unit)
+    namespace.InsertUnit('measurement', unit)
     unit_universe = unit_lib.UnitUniverse([folder])
 
     findings = unit_universe.GetFindings()
@@ -66,23 +66,25 @@ class UnitLibTest(absltest.TestCase):
 
   def testUnitFolderAddValidUnit(self):
     folder = unit_lib.UnitFolder(_GOOD_PATH)
-    folder.AddUnit(unit_lib.Unit('unit', 'measurement'))
-    self.assertIn('unit', folder.local_namespace.units)
+    folder.AddUnit('measurement', unit_lib.Unit('unit'))
+    units = folder.local_namespace.GetUnitsForMeasurement('measurement')
+    self.assertIn('unit', units)
     self.assertEmpty(folder.GetFindings())
 
   def testUnitFolderAddInvalidUnitFails(self):
     folder = unit_lib.UnitFolder(_GOOD_PATH)
-    folder.AddUnit(unit_lib.Unit('bad-unit', 'invalid'))
-    self.assertNotIn('bad-unit', folder.local_namespace.units)
+    folder.AddUnit('invalid', unit_lib.Unit('bad-unit'))
+    self.assertIsNone(folder.local_namespace.GetUnitsForMeasurement('invalid'))
     self.assertIsInstance(folder.GetFindings()[0],
                           findings_lib.InvalidUnitNameError)
 
   def testUnitFolderAddDuplicateUnitFails(self):
     folder = unit_lib.UnitFolder(_GOOD_PATH)
-    folder.AddUnit(unit_lib.Unit('unit', 'measurement'))
-    self.assertIn('unit', folder.local_namespace.units)
+    folder.AddUnit('measurement', unit_lib.Unit('unit'))
+    units = folder.local_namespace.GetUnitsForMeasurement('measurement')
+    self.assertIn('unit', units)
     self.assertEmpty(folder.local_namespace.GetFindings())
-    folder.AddUnit(unit_lib.Unit('unit', 'duplicate'))
+    folder.AddUnit('measurement', unit_lib.Unit('unit'))
     self.assertIsInstance(folder.local_namespace.GetFindings()[0],
                           findings_lib.DuplicateUnitDefinitionError)
 
@@ -95,13 +97,13 @@ class UnitLibTest(absltest.TestCase):
     folder = unit_lib.UnitFolder(_GOOD_PATH)
     folder.AddFromConfig([doc], '{0}/file.yaml'.format(_GOOD_PATH))
 
-    units = folder.local_namespace.units
+    units = folder.local_namespace.GetUnitsForMeasurement('temperature')
     self.assertEmpty(folder.GetFindings())
     self.assertCountEqual(['kelvins', 'degrees_celsius'], units)
     self.assertEqual(units['kelvins'],
-                     unit_lib.Unit('kelvins', 'temperature', True))
+                     unit_lib.Unit('kelvins', True))
     self.assertEqual(units['degrees_celsius'],
-                     unit_lib.Unit('degrees_celsius', 'temperature', False))
+                     unit_lib.Unit('degrees_celsius', False))
 
   def testUnitFolderAddFromConfigMultipleNoUnits(self):
     doc = {
@@ -114,11 +116,12 @@ class UnitLibTest(absltest.TestCase):
     }
     folder = unit_lib.UnitFolder(_GOOD_PATH)
     folder.AddFromConfig([doc], '{0}/file.yaml'.format(_GOOD_PATH))
-    units = folder.local_namespace.units
+    pf_units = folder.local_namespace.GetUnitsForMeasurement('powerfactor')
+    vr_units = folder.local_namespace.GetUnitsForMeasurement('voltageratio')
 
     self.assertEmpty(folder.GetFindings())
-    expected = ['no_units_powerfactor', 'another_one', 'no_units_voltageratio']
-    self.assertCountEqual(expected, units)
+    self.assertCountEqual(['no_units', 'another_one'], pf_units)
+    self.assertCountEqual(['no_units'], vr_units)
 
   def testUnitFolderAddFromConfigInvalidUnitFormat(self):
     doc = {
@@ -170,25 +173,73 @@ class UnitLibTest(absltest.TestCase):
                           findings_lib.StandardUnitCountError)
 
   def testUnitWithIllegalKeyTypeHasFindings(self):
-    unit = unit_lib.Unit(False, 'invalid')
+    unit = unit_lib.Unit(False)
     self.assertIsInstance(unit.GetFindings()[0],
                           findings_lib.IllegalKeyTypeError)
 
   def testUnitWithIllegalNameHasFindings(self):
-    unit = unit_lib.Unit('BADUNIT', 'invalid')
+    unit = unit_lib.Unit('BADUNIT')
     self.assertIsInstance(unit.GetFindings()[0],
                           findings_lib.InvalidUnitNameError)
 
   def testUnitEquals(self):
-    unit_one = unit_lib.Unit('unit_one', 'measurement')
-    unit_one_dup = unit_lib.Unit('unit_one', 'measurement')
-    unit_one_diff_measurement = unit_lib.Unit('unit_one', 'changed')
-    unit_one_standard = unit_lib.Unit('unit_one', 'measurement', True)
-    unit_two = unit_lib.Unit('unit_two', 'measurement')
+    unit_one = unit_lib.Unit('unit_one')
+    unit_one_dup = unit_lib.Unit('unit_one')
+    unit_one_standard = unit_lib.Unit('unit_one', True)
+    unit_two = unit_lib.Unit('unit_two')
     self.assertEqual(unit_one, unit_one_dup)
-    self.assertNotEqual(unit_one, unit_one_diff_measurement)
     self.assertNotEqual(unit_one, unit_one_standard)
     self.assertNotEqual(unit_one, unit_two)
+
+  def testUnitFolderAddFromConfigMeasurementAlias(self):
+    doc = {
+      'length': 'distance',
+      'distance': [
+        {'meters': 'STANDARD'},
+        'feet'
+      ],
+    }
+    folder = unit_lib.UnitFolder(_GOOD_PATH)
+    expected_units = ['meters', 'feet']
+
+    folder.AddFromConfig([doc], '{0}/file.yaml'.format(_GOOD_PATH))
+    distance_units = folder.local_namespace.GetUnitsForMeasurement('distance')
+    length_units = folder.local_namespace.GetUnitsForMeasurement('length')
+
+    self.assertEmpty(folder.local_namespace.GetFindings())
+    self.assertCountEqual(expected_units, distance_units)
+    self.assertCountEqual(expected_units, length_units)
+
+  def testUnitFolderAddFromConfigBadAliasBase(self):
+    doc = {
+      'length': 'invalid',
+      'distance': [
+        {'meters': 'STANDARD'},
+        'feet'
+      ],
+    }
+    folder = unit_lib.UnitFolder(_GOOD_PATH)
+
+    folder.AddFromConfig([doc], '{0}/file.yaml'.format(_GOOD_PATH))
+
+    self.assertIsInstance(folder.local_namespace.GetFindings()[0],
+                          findings_lib.UnrecognizedMeasurementAliasBaseError)
+
+  def testUnitFolderAddFromConfigAliasIsAlias(self):
+    doc = {
+      'distance': [
+        {'meters': 'STANDARD'},
+        'feet'
+      ],
+      'length': 'distance',
+      'level': 'length',
+    }
+    folder = unit_lib.UnitFolder(_GOOD_PATH)
+
+    folder.AddFromConfig([doc], '{0}/file.yaml'.format(_GOOD_PATH))
+
+    self.assertIsInstance(folder.local_namespace.GetFindings()[0],
+                          findings_lib.MeasurementAliasIsAliasedError)
 
 
 if __name__ == '__main__':

--- a/tools/validators/ontology_validator/yamlformat/validator/findings_lib.py
+++ b/tools/validators/ontology_validator/yamlformat/validator/findings_lib.py
@@ -578,6 +578,51 @@ class MissingUnitError(ValidationError):
         .format(subfield.name), subfield.file_context)
 
 
+class MeasurementAliasIsAliasedError(ValidationError):
+  """Measurement subfield is aliased to another aliased subfield."""
+
+  def __init__(self, alias):
+    """Init.
+
+    Args:
+      alias: The invalid MeasurementAlias object.
+    """
+    super(MeasurementAliasIsAliasedError, self).__init__(
+        'Measurement subfield "{0}" is not allowed to be an alias of "{1}" '
+        'because that subfield is also an alias.'
+        .format(alias.alias_name, alias.base_name), alias.file_context)
+
+
+class UnrecognizedMeasurementAliasBaseError(ValidationError):
+  """A measurement subfield is an alias of an unrecognized subfield."""
+
+  def __init__(self, alias):
+    """Init.
+
+    Args:
+      alias: The invalid MeasurementAlias object.
+    """
+    super(UnrecognizedMeasurementAliasBaseError, self).__init__(
+        'The alias definition of measurement subfield "{0}" references '
+        'unrecognized subfield "{1}".'.format(
+            alias.alias_name, alias.base_name), alias.file_context)
+
+
+class DuplicateMeasurementAliasError(DuplicateDefinitionError):
+  """A measurement type alias has been defined more than once."""
+
+  def __init__(self, namespace, alias, prev_context):
+    """Init.
+
+    Args:
+      namespace: The UnitNamespace that the alias is defined in.
+      alias: The invalid MeasurementAlias object.
+      prev_context: FileContext of the previous definition of the alias.
+    """
+    super(DuplicateMeasurementAliasError, self).__init__('measurement alias',
+        namespace, alias.alias_name, alias.context, prev_context)
+
+
 # ---------------------------------------------------------------------------- #
 # Errors relating to States.
 # ---------------------------------------------------------------------------- #
@@ -731,10 +776,10 @@ class StandardUnitCountError(ValidationError):
 class UnknownMeasurementTypeError(ValidationError):
   """A unit has an unknown measurement type."""
 
-  def __init__(self, unit):
+  def __init__(self, unit, measurement_type):
     super(UnknownMeasurementTypeError, self).__init__(
         'Unit "{0}" is defined under the unrecognized measurement type "{1}".'
-        .format(unit.name, unit.measurement_type), unit.file_context)
+        .format(unit.name, measurement_type), unit.file_context)
 
 
 # ---------------------------------------------------------------------------- #

--- a/tools/validators/ontology_validator/yamlformat/validator/findings_lib.py
+++ b/tools/validators/ontology_validator/yamlformat/validator/findings_lib.py
@@ -620,7 +620,7 @@ class DuplicateMeasurementAliasError(DuplicateDefinitionError):
       prev_context: FileContext of the previous definition of the alias.
     """
     super(DuplicateMeasurementAliasError, self).__init__('measurement alias',
-        namespace, alias.alias_name, alias.context, prev_context)
+        namespace, alias.alias_name, alias.file_context, prev_context)
 
 
 # ---------------------------------------------------------------------------- #

--- a/tools/validators/ontology_validator/yamlformat/validator/presubmit_validate_types_lib.py
+++ b/tools/validators/ontology_validator/yamlformat/validator/presubmit_validate_types_lib.py
@@ -156,6 +156,8 @@ class ConfigUniverse(findings_lib.Findings):
         incremented.
     Returns: a string representing the unit or None if units are defined.
     """
+    if not self.unit_universe:
+      return None
     subfields = as_written_field_name.split('_')
     # if the last element is numeric need to remove it
     while subfields[-1].isnumeric():

--- a/tools/validators/ontology_validator/yamlformat/validator/subfield_lib.py
+++ b/tools/validators/ontology_validator/yamlformat/validator/subfield_lib.py
@@ -228,10 +228,7 @@ class SubfieldNamespace(findings_lib.Findings):
     Args:
       unit_universe: UnitUniverse object used to look up units
     """
-    unit_measurement_types = {
-        unit.measurement_type
-        for unit in unit_universe.GetUnitsMap(self.namespace).values()
-    }
+    unit_measurement_types = unit_universe.GetMeasurementTypes()
     for subfield in self.subfields.values():
       if (subfield.category == SubfieldCategory.MEASUREMENT and
           subfield.name not in unit_measurement_types):

--- a/tools/validators/ontology_validator/yamlformat/validator/unit_lib.py
+++ b/tools/validators/ontology_validator/yamlformat/validator/unit_lib.py
@@ -299,7 +299,6 @@ class UnitNamespace(findings_lib.Findings):
       else:
         for unit in self._units_by_measurement[alias.base_name].values():
           self._InsertEffectiveUnit(alias.alias_name, unit)
-    self._measurement_aliases = {}
 
   def GetUnitsForMeasurement(self, measurement_type):
     """Returns the collection of units that are defined for the given

--- a/tools/validators/ontology_validator/yamlformat/validator/unit_lib.py
+++ b/tools/validators/ontology_validator/yamlformat/validator/unit_lib.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import re
+from typing import NamedTuple
 
 from yamlformat.validator import base_lib
 from yamlformat.validator import config_folder_lib
@@ -28,31 +29,49 @@ UNIT_NAME_VALIDATOR = re.compile(r'^[a-z]+(_[a-z]+)*$')
 STANDARD_UNIT_TAG = 'STANDARD'
 
 
+_MeasurementAlias = NamedTuple('MeasurementAlias', [
+  ('alias_name', str),
+  ('base_name', str),
+  ('file_context', findings_lib.FileContext)
+])
+
+
 class UnitUniverse(findings_lib.FindingsUniverse):
   """Helper class to represent the defined universe of units."""
 
   def _GetNamespaceMapValue(self, namespace):
     """Helper method for FindingsUniverse._MakeNamespaceMap.
 
-    Used to create a map from namespace names to unit maps.
+    Used to create a map from namespace names to namespaces.
 
     Args:
       namespace: UnitNamespace
 
     Returns:
-      The units map from the namespace.
+      The namespace.
     """
-    return namespace.units
+    return namespace
 
-  def GetUnitsMap(self, namespace_name):
-    """Returns a map from unit names to Unit objects in the namespace.
-
-    If there are no defined units in the namespace, returns an empty dict.
+  def GetUnitsForMeasurement(self, measurement_type, namespace_name=''):
+    """Returns the collection of units that are defined for the given
+    measurement type as a dictionary from unit names to Unit objects, or None
+    if there are no units for that measurement type.
 
     Args:
-      namespace_name: string.
+      measurement_type: Name of the measurement subfield.
+      namespace_name: Name of the namespace.
     """
-    return self._namespace_map.get(namespace_name, {})
+    return self._namespace_map[namespace_name].GetUnitsForMeasurement(
+        measurement_type)
+
+  def GetMeasurementTypes(self, namespace_name=''):
+    """Returns the list of measurement type names that have units defined in the
+    namespace.
+
+    Args:
+      namespace_name: Name of the namespace.
+    """
+    return self._namespace_map[namespace_name].GetMeasurementTypes()
 
 
 class UnitFolder(config_folder_lib.ConfigFolder):
@@ -81,7 +100,7 @@ class UnitFolder(config_folder_lib.ConfigFolder):
                                          local_subfields)
     self.parent_namespace = parent_namespace
 
-  def AddUnit(self, unit):
+  def AddUnit(self, measurement_type, unit):
     """Validates a unit and adds it to the correct namespace.
 
     Findings will be added to the UnitFolder if validation finds any problems.
@@ -89,12 +108,13 @@ class UnitFolder(config_folder_lib.ConfigFolder):
     if validation fails.
 
     Args:
+      measurement_type: Name of the measurement subfield.
       unit: Unit object to add.
     """
     if not unit.IsValid():
       self.AddFindings(unit.GetFindings())
       return
-    self.local_namespace.InsertUnit(unit)
+    self.local_namespace.InsertUnit(measurement_type, unit)
 
   def _AddFromConfigHelper(self, document, context):
     """Helper method that reads a single yaml document and adds all units found.
@@ -105,34 +125,37 @@ class UnitFolder(config_folder_lib.ConfigFolder):
     """
     for measurement in document:
       standard_tag_count = 0
-      units = document[measurement]
-      for unit in units:
-        is_standard = False
-        unit_name = ''
-        if isinstance(unit, dict):
-          if len(unit) == 1:
-            unit_name, tag = next(iter(unit.items()))
+      content = document[measurement]
+      if isinstance(content, str):
+        self.local_namespace.InsertMeasurementAlias(_MeasurementAlias(
+            measurement, content, context))
+      else:
+        for unit in content:
+          is_standard = False
+          unit_name = ''
+          if isinstance(unit, dict):
+            if len(unit) == 1:
+              unit_name, tag = next(iter(unit.items()))
+            else:
+              unit_name = next(iter(unit), '(Blank)')
+              self.AddFinding(
+                  findings_lib.InvalidUnitFormatError(unit_name, context))
+              continue
+            if tag == STANDARD_UNIT_TAG:
+              is_standard = True
+              standard_tag_count += 1
+            else:
+              self.AddFinding(
+                  findings_lib.UnknownUnitTagError(unit_name, tag, context))
           else:
-            unit_name = next(iter(unit), '(Blank)')
-            self.AddFinding(
-                findings_lib.InvalidUnitFormatError(unit_name, context))
-            continue
-          if tag == STANDARD_UNIT_TAG:
-            is_standard = True
-            standard_tag_count += 1
-          else:
-            self.AddFinding(
-                findings_lib.UnknownUnitTagError(unit_name, tag, context))
-        else:
-          unit_name = unit
-        # Avoid name clashes when there are multiple dimensionless measurements.
-        if unit_name == 'no_units':
-          unit_name += '_' + measurement
-        self.AddUnit(Unit(unit_name, measurement, is_standard, context))
-      if standard_tag_count != 1:
-        self.AddFinding(
-            findings_lib.StandardUnitCountError(measurement, standard_tag_count,
-                                                context))
+            unit_name = unit
+          self.AddUnit(measurement, Unit(unit_name, is_standard, context))
+        if standard_tag_count != 1:
+          self.AddFinding(
+              findings_lib.StandardUnitCountError(measurement,
+                                                  standard_tag_count,
+                                                  context))
+    self.local_namespace.ResolveMeasurementAliases()
 
 
 class UnitNamespace(findings_lib.Findings):
@@ -143,7 +166,8 @@ class UnitNamespace(findings_lib.Findings):
     parent_namespace: global UnitNamespace, or None if this is the global
       namespace.
     subfields: map of subfield names to Subfields defined in this namespace.
-    units: a map from unit names to Unit objects defined in this namespace.
+    units: a map from namespace-unique unit identifiers to Unit objects defined
+      in this namespace.
   """
 
   def __init__(self, namespace, parent_namespace=None, subfields=None):
@@ -161,6 +185,9 @@ class UnitNamespace(findings_lib.Findings):
     self.parent_namespace = parent_namespace
     self.subfields = subfields
     self.units = {}
+    self._units_by_name = {}
+    self._units_by_measurement = {}
+    self._measurement_aliases = {}
 
   def _GetDynamicFindings(self, filter_old_warnings):
     findings = []
@@ -177,13 +204,14 @@ class UnitNamespace(findings_lib.Findings):
     """
     return self.subfields is not None
 
-  def ValidateMeasurementType(self, unit):
+  def ValidateMeasurementType(self, measurement_type, unit):
     """Validates that the unit corresponds to a measurement type subfield.
 
     Subfields defined in either the local namespace or global namespace are
     valid. If a match is not found, a finding is added to the unit.
 
     Args:
+      measurement_type: Name of the measurement subfield.
       unit: Unit object to validate.
     """
     pns = self.parent_namespace
@@ -192,11 +220,12 @@ class UnitNamespace(findings_lib.Findings):
       # If subfields are undefined on any relevant namespace, proper validation
       # is impossible. An empty subfield list counts as being defined.
       return
-    if (unit.measurement_type not in self.subfields and
-        (pns is None or unit.measurement_type not in pns.subfields)):
-      unit.AddFinding(findings_lib.UnknownMeasurementTypeError(unit))
+    if (measurement_type not in self.subfields and
+        (pns is None or measurement_type not in pns.subfields)):
+      unit.AddFinding(findings_lib.UnknownMeasurementTypeError(
+          unit, measurement_type))
 
-  def InsertUnit(self, unit):
+  def InsertUnit(self, measurement_type, unit):
     """Inserts a unit into this namespace.
 
     If the unit already exists in the namespace, adds a
@@ -204,15 +233,89 @@ class UnitNamespace(findings_lib.Findings):
     inserted.
 
     Args:
+      measurement_type: Name of the measurement subfield.
       unit: unit object to attempt to insert.
     """
-    self.ValidateMeasurementType(unit)
-    if unit.name in self.units:
-      prev_context = self.units[unit.name].file_context
-      self.AddFinding(
-          findings_lib.DuplicateUnitDefinitionError(self, unit, prev_context))
+    if unit.name != 'no_units' and unit.name in self._units_by_name:
+      self.AddFinding(findings_lib.DuplicateUnitDefinitionError(self, unit,
+          self._units_by_name[unit.name].file_context))
       return
-    self.units[unit.name] = unit
+    self._InsertEffectiveUnit(measurement_type, unit)
+
+  def _InsertEffectiveUnit(self, measurement_type, unit):
+    """Inserts a unit into this namespace.  Does not check for uniqueness
+    within the namespace.
+
+    If the unit already exists in the measurement, adds a
+    DuplicateUnitDefinitionError to the findings and the duplicate is not
+    inserted.
+
+    Args:
+      measurement_type: Name of the measurement subfield.
+      unit: unit object to attempt to insert.
+    """
+    self.ValidateMeasurementType(measurement_type, unit)
+    measurement_units = self._units_by_measurement.setdefault(
+        measurement_type, {})
+    if unit.name in measurement_units:
+      self.AddFinding(findings_lib.DuplicateUnitDefinitionError(self, unit,
+          measurement_units[unit.name].file_context))
+      return
+    measurement_units[unit.name] = unit
+    self._units_by_name[unit.name] = unit
+    # unit_key is an opaque ID that is unique within the namespace. It is only
+    # used by the backward compatibility checking, which needs all of the units
+    # to be in a single dict.
+    unit_key = '{0}-{1}'.format(measurement_type, unit.name)
+    self.units[unit_key] = unit
+
+  def InsertMeasurementAlias(self, alias):
+    """Inserts a measurement alias into this namespace.
+
+    If the alias already exists in the namespace, adds a
+    DuplicateMeasurementAliasError to the findings and the duplicate is not
+    inserted.
+
+    Args:
+      alias: _MeasurementAlias object to insert.
+    """
+    if alias.alias_name in self._measurement_aliases:
+      prev_instance = self._measurement_aliases[alias.alias_name]
+      self.AddFinding(findings_lib.DuplicateMeasurementAliasError(
+          self, alias, prev_instance.file_context))
+      return
+    self._measurement_aliases[alias.alias_name] = alias
+
+  def ResolveMeasurementAliases(self):
+    """Validates all measurement alias references and populates the collections
+    of units for all aliased measurement types.
+    """
+    for alias in self._measurement_aliases.values():
+      if alias.base_name in self._measurement_aliases:
+        self.AddFinding(findings_lib.MeasurementAliasIsAliasedError(alias))
+      elif alias.base_name not in self._units_by_measurement:
+        self.AddFinding(findings_lib.UnrecognizedMeasurementAliasBaseError(
+            alias))
+      else:
+        for unit in self._units_by_measurement[alias.base_name].values():
+          self._InsertEffectiveUnit(alias.alias_name, unit)
+    self._measurement_aliases = {}
+
+  def GetUnitsForMeasurement(self, measurement_type):
+    """Returns the collection of units that are defined for the given
+    measurement type as a dictionary from unit names to Unit objects, or None
+    if there are no units for that measurement type.
+
+    Args:
+      measurement_type: Name of the measurement subfield.
+    """
+    return self._units_by_measurement.get(measurement_type)
+
+  def GetMeasurementTypes(self):
+    """Returns the list of measurement type names that have units defined in the
+    namespace.
+    """
+    return self._units_by_measurement.keys()
 
 
 class Unit(findings_lib.Findings):
@@ -220,21 +323,15 @@ class Unit(findings_lib.Findings):
 
   Attributes:
     name: the full name (without namespace) of this unit
-    measurement_type: the unit measurement type
     is_standard: whether this is the standard unit for the measurement type
     file_context: the config file context for where this unit was defined
   """
 
-  def __init__(self,
-               name,
-               measurement_type,
-               is_standard=False,
-               file_context=None):
+  def __init__(self, name, is_standard=False, file_context=None):
     """Init.
 
     Args:
       name: required string name for the unit
-      measurement_type: required string indicating the unit measurement type
       is_standard: whether this is the standard unit for the measurement type
       file_context: optional object with the config file location of this unit.
 
@@ -243,7 +340,6 @@ class Unit(findings_lib.Findings):
     """
     super(Unit, self).__init__()
     self.name = name
-    self.measurement_type = measurement_type
     self.is_standard = is_standard
     self.file_context = file_context
 
@@ -255,7 +351,6 @@ class Unit(findings_lib.Findings):
   def __eq__(self, other):
     if isinstance(other, Unit):
       return (self.name == other.name and
-              self.measurement_type == other.measurement_type and
               self.is_standard == other.is_standard)
     return False
 


### PR DESCRIPTION
This branch adds the proposed measurement aliasing feature to the ontology validator.

* Added syntax for measurements that copy another measurement.
* Adjusted UnitUniverse and UnitNamespace methods for better encapsulation.
* Removed the Unit.measurement_type field. Instead, UnitNamespace now maintains a map from measurements to the list of units that belong to it.
* At the end of processing the unit file, each aliased measurement copies the units that were defined in the base measurement.
* 'no_units' is still the only unit name that is allowed to appear more than once in the units YAML file, any other duplication is achieved through measurement aliasing.