### PR TITLE
New ERV bypass and RAD opt use for ECON

### DIFF
--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -1464,7 +1464,6 @@ DX2ZC:
   - cooling_thermal_power_capacity
   - cooling_percentage_command
   - compressor_speed_percentage_command
-  - cooling_stage_run_count
   uses:
   - zone_air_cooling_temperature_setpoint
   - zone_air_temperature_sensor

--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -1464,6 +1464,7 @@ DX2ZC:
   - cooling_thermal_power_capacity
   - cooling_percentage_command
   - compressor_speed_percentage_command
+  - cooling_stage_run_count
   uses:
   - zone_air_cooling_temperature_setpoint
   - zone_air_temperature_sensor

--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -2335,6 +2335,7 @@ ECON:
   - supply_air_temperature_sensor
   - outside_air_flowrate_sensor
   - outside_air_flowrate_setpoint
+  - return_air_damper_percentage_command
   uses:
   - outside_air_temperature_sensor
   - economizer_mode
@@ -2357,6 +2358,7 @@ ECOND:
   - mixed_air_temperature_sensor
   - outside_air_damper_percentage_sensor
   - low_limit_outside_air_damper_percentage_command
+  - return_air_damper_percentage_command
   uses:
   - outside_air_temperature_sensor
   - economizer_mode
@@ -2376,6 +2378,7 @@ ECONM:
   - supply_air_temperature_sensor
   - outside_air_damper_percentage_sensor
   - low_limit_outside_air_damper_percentage_command
+  - return_air_damper_percentage_command
   uses:
   - outside_air_temperature_sensor
   - economizer_mode
@@ -2396,6 +2399,7 @@ ECONM2X:
   - supply_air_temperature_sensor
   - outside_air_damper_percentage_sensor
   - low_limit_outside_air_damper_percentage_command
+  - return_air_damper_percentage_command
   uses:
   - outside_air_temperature_sensor
   - economizer_mode
@@ -2418,6 +2422,7 @@ ECONMD:
   - outside_air_flowrate_setpoint
   - return_air_temperature_sensor
   - outside_air_damper_percentage_sensor
+  - return_air_damper_percentage_command
   uses:
   - outside_air_temperature_sensor
   - economizer_mode
@@ -2439,6 +2444,7 @@ ECONZ:
   - return_air_temperature_sensor
   - mixed_air_temperature_sensor
   - outside_air_damper_percentage_sensor
+  - return_air_damper_percentage_command
   uses:
   - outside_air_temperature_sensor
   - economizer_mode

--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -1404,6 +1404,7 @@ DX2ZTC:
   - cooling_thermal_power_capacity
   - cooling_percentage_command
   - compressor_speed_percentage_command
+  - cooling_stage_run_count
   uses:
   - zone_air_temperature_setpoint
   - zone_air_temperature_sensor

--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -1404,7 +1404,6 @@ DX2ZTC:
   - cooling_thermal_power_capacity
   - cooling_percentage_command
   - compressor_speed_percentage_command
-  - cooling_stage_run_count
   uses:
   - zone_air_temperature_setpoint
   - zone_air_temperature_sensor

--- a/ontology/yaml/resources/fields/telemetry_fields.yaml
+++ b/ontology/yaml/resources/fields/telemetry_fields.yaml
@@ -1039,3 +1039,6 @@ literals:
 - fivesecondrolling_rootmeansquare_zaxis_linearacceleration_sensor
 - local_air_temperature_sensor
 
+# New fields for ERV bypass
+- bypass_air_damper_command
+- bypass_air_damper_status


### PR DESCRIPTION
Added binary bypass damper fields and optional RAD percentage commands to all ECON ABSTRACT types. @tasodorff @tsodorff @mschulze17 