### PR TITLE
Updated CHWSC types

### DIFF
--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -1290,6 +1290,7 @@ CHWSC:
   - leaving_cooling_coil_temperature_sensor
   - cooling_thermal_power_capacity
   - chilled_supply_water_temperature_sensor
+  - chilled_water_valve_percentage_sensor
   uses:
   - supply_air_temperature_sensor
   - supply_air_temperature_setpoint
@@ -1304,6 +1305,7 @@ CHWSDC:
   opt_uses:
   - leaving_cooling_coil_temperature_sensor
   - cooling_thermal_power_capacity
+  - chilled_water_valve_percentage_sensor
   uses:
   - supply_air_temperature_sensor
   - supply_air_heating_temperature_setpoint
@@ -1320,6 +1322,7 @@ CHW2XSC:
   - leaving_cooling_coil_temperature_sensor
   - cooling_thermal_power_capacity
   - chilled_supply_water_temperature_sensor
+  - chilled_water_valve_percentage_sensor
   uses:
   - supply_air_temperature_sensor
   - supply_air_temperature_setpoint


### PR DESCRIPTION
Added chilled_water_valve_percentage_sensor to opt_uses for CHWSC and similar types.
@tasodorff @tsodorff @mschulze17 