### PR TITLE
reactive_power to reactivepower

### DIFF
--- a/ontology/yaml/resources/METERS/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/METERS/entity_types/ABSTRACT.yaml
@@ -21,7 +21,7 @@ PWM:
   is_abstract: true
   opt_uses:
   - apparent_power_sensor
-  - reactive_power_sensor
+  - reactivepower_sensor
   - powerfactor_sensor
   - line_frequency_sensor
   - apparent_energy_accumulator
@@ -50,9 +50,9 @@ PLPM:
   - phase1_apparent_power_sensor
   - phase2_apparent_power_sensor
   - phase3_apparent_power_sensor
-  - phase1_reactive_power_sensor
-  - phase2_reactive_power_sensor
-  - phase3_reactive_power_sensor
+  - phase1_reactivepower_sensor
+  - phase2_reactivepower_sensor
+  - phase3_reactivepower_sensor
   uses:
   - phase1_power_sensor
   - phase2_power_sensor

--- a/ontology/yaml/resources/fields/telemetry_fields.yaml
+++ b/ontology/yaml/resources/fields/telemetry_fields.yaml
@@ -521,10 +521,10 @@ literals:
 - phase3_power_sensor
 - phase3_powerfactor_sensor
 - powerfactor_sensor
-- reactive_power_sensor
-- phase1_reactive_power_sensor
-- phase2_reactive_power_sensor
-- phase3_reactive_power_sensor
+- reactivepower_sensor
+- phase1_reactivepower_sensor
+- phase2_reactivepower_sensor
+- phase3_reactivepower_sensor
 
 # Added on 2019/06/27 for Enlighted
 - dimmer_percentage_command # Should be adjusted to brightness_percentage_command


### PR DESCRIPTION
Changing the reactive power measurement name to match the unit specification