### PR TITLE
Patching the telemetry validator to udmi errors

### DIFF
--- a/tools/validators/instance_validator/validate/telemetry.py
+++ b/tools/validators/instance_validator/validate/telemetry.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the License);
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 
 from __future__ import print_function
 import json
-import numbers
 from typing import Dict, Tuple
 
 from validate import point

--- a/tools/validators/instance_validator/validate/telemetry.py
+++ b/tools/validators/instance_validator/validate/telemetry.py
@@ -83,6 +83,9 @@ class Telemetry(object):
                   message) -> Tuple[str, str, Dict[str, point.Point], bool]:
     """Receives a pubsub message data and parses it.
 
+    Handles parsing as outlined in:
+    https://faucetsdn.github.io/udmi/gencode/docs/event_pointset.html
+
     Args:
       message: pubsub telemetry payload, UDMI compliant
 
@@ -109,6 +112,7 @@ class Telemetry(object):
       if type(json_object) is int:
         print(f'Received an invalid Json payload containing: \n{json_object}')
         return version, timestamp, points, is_partial
+
       # UDMI v1 sends as int and v1+ sends version as String
       if VERSION not in json_object.keys():
         print('Error: no version in ', json_object)

--- a/tools/validators/instance_validator/validate/telemetry.py
+++ b/tools/validators/instance_validator/validate/telemetry.py
@@ -116,12 +116,12 @@ class Telemetry(object):
       # UDMI v1 sends as int and v1+ sends version as String
       if VERSION not in json_object.keys():
         print('Error: no version in ', json_object)
-      return version, timestamp, points, is_partial
+        return version, timestamp, points, is_partial
       version = str(json_object[VERSION])
 
       if TIMESTAMP not in json_object.keys():
         print('Error: no timestamp in ', json_object)
-      return version, timestamp, points, is_partial
+        return version, timestamp, points, is_partial
       timestamp = json_object[TIMESTAMP]
 
       is_partial = bool(json_object.get(PARTIAL_UPDATE, False))

--- a/tools/validators/instance_validator/validate/telemetry.py
+++ b/tools/validators/instance_validator/validate/telemetry.py
@@ -98,7 +98,7 @@ class Telemetry(object):
     """
     version, timestamp, points, is_partial = (None, None, None, None)
     try:
-      if type(message) is int:
+      if isinstance(message, int):
         print(f'Received an invalid message (non Json payload)\n{message}')
         return version, timestamp, points, is_partial
       json_object = json.loads(message)
@@ -109,7 +109,7 @@ class Telemetry(object):
     except ValueError:
       print(f'The following Json raised an ValueError error:\n{message}')
     else:
-      if type(json_object) is int:
+      if isinstance(json_object, int):
         print(f'Received an invalid Json payload containing: \n{json_object}')
         return version, timestamp, points, is_partial
 

--- a/tools/validators/instance_validator/validate/telemetry.py
+++ b/tools/validators/instance_validator/validate/telemetry.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the License);
 # you may not use this file except in compliance with the License.
@@ -120,6 +120,8 @@ class Telemetry(object):
         print('Error: no timestamp in ', json_object)
       return version, timestamp, points, is_partial
       timestamp = json_object[TIMESTAMP]
+
+      is_partial = bool(json_object.get(PARTIAL_UPDATE, False))
 
       points = {}
       if POINTS not in json_object.keys():

--- a/tools/validators/instance_validator/validate/telemetry.py
+++ b/tools/validators/instance_validator/validate/telemetry.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the License);
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 
 from __future__ import print_function
 import json
+import numbers
 from typing import Dict, Tuple
 
 from validate import point
@@ -95,15 +96,31 @@ class Telemetry(object):
     """
     version, timestamp, points, is_partial = (None, None, None, None)
     try:
+      if type(message) is int:
+        print(f'Received an invalid message (non Json payload)\n{message}')
+        return version, timestamp, points, is_partial
       json_object = json.loads(message)
     except json.JSONDecodeError:
       print(f'The following Json payload is invalid:\n{message}')
     except AttributeError:
       print(f'The following Json raised an attribute error:\n{message}')
+    except ValueError:
+      print(f'The following Json raised an ValueError error:\n{message}')
     else:
-      version = json_object[VERSION]
+      if type(json_object) is int:
+        print(f'Received an invalid Json payload containing: \n{json_object}')
+        return version, timestamp, points, is_partial
+      # UDMI v1 sends as int and v1+ sends version as String
+      if VERSION not in json_object.keys():
+        print('Error: no version in ', json_object)
+      return version, timestamp, points, is_partial
+      version = str(json_object[VERSION])
+
+      if TIMESTAMP not in json_object.keys():
+        print('Error: no timestamp in ', json_object)
+      return version, timestamp, points, is_partial
       timestamp = json_object[TIMESTAMP]
-      is_partial = bool(json_object.get(PARTIAL_UPDATE, False))
+
       points = {}
       if POINTS not in json_object.keys():
         print('Error: no points in ', json_object)


### PR DESCRIPTION
Some devices are sending non conform udmi messages such as `1` or empty bytes.
Some udmi devices set the version as int for version 1. or string for version 1+