### PR TITLE
Doc links fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
 theme: jekyll-theme-cayman
-
 url: https://google.github.io
 baseurl: '/digitalbuildings'

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,2 @@
 theme: jekyll-theme-cayman
-url: https://google.github.io
 baseurl: '/digitalbuildings'


### PR DESCRIPTION
One more shot at fixing this. Referring to Stack Overflow and Jekyll documentation:

https://stackoverflow.com/questions/16316311/github-pages-and-relative-paths