### PR TITLE
P1 deprecated the id but not break it

### DIFF
--- a/tools/validators/instance_validator/tests/entity_instance_test.py
+++ b/tools/validators/instance_validator/tests/entity_instance_test.py
@@ -1016,7 +1016,7 @@ class EntityInstanceTest(absltest.TestCase):
 
     self.assertFalse(self.update_validator.Validate(entity))
 
-  def testValidateGoodUpdateOperationDefaultExport(self):
+  def testValidate_GoodUpdateOperationDefaultExport_Success(self):
     parsed, default_operation = _Helper([
         path.join(_TESTCASE_PATH, 'GOOD',
                   'update_no_operation_default_export.yaml')
@@ -1038,6 +1038,25 @@ class EntityInstanceTest(absltest.TestCase):
         combination_validator.Validate(entity_instances['VIRTUAL-ENTITY-GUID']))
     self.assertEqual(entity_instances['PHYSICAL-ENTITY-GUID'].operation,
                      _EXPORT)
+
+  def testValidate_buildingConfigEntityWithId_Success(self):
+    parsed, default_operation = _Helper(
+        [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
+    entity_iter = iter(parsed.items())
+    entity_1_guid, entity_1_block = next(entity_iter)
+    entity_2_guid, entity_2_block = next(entity_iter)
+
+    entity_1 = entity_instance.EntityInstance.FromYaml(
+        entity_1_guid, entity_1_block, default_operation=default_operation)
+    entity_2 = entity_instance.EntityInstance.FromYaml(
+        entity_2_guid, entity_2_block, default_operation=default_operation)
+
+    self.assertTrue(self.init_validator.Validate(entity_1))
+    self.assertFalse(entity_instance.IsEntityIdPresent(entity_1))
+    self.assertTrue(self.init_validator.Validate(entity_2))
+    self.assertTrue(entity_instance.IsEntityIdPresent(entity_2))
+    self.assertEqual(entity_2._id,
+        parsed['UK-LON-S2-GUID'].get(instance_parser.ENTITY_ID_KEY))
 
 if __name__ == '__main__':
   absltest.main()

--- a/tools/validators/instance_validator/tests/entity_instance_test.py
+++ b/tools/validators/instance_validator/tests/entity_instance_test.py
@@ -1039,7 +1039,7 @@ class EntityInstanceTest(absltest.TestCase):
     self.assertEqual(entity_instances['PHYSICAL-ENTITY-GUID'].operation,
                      _EXPORT)
 
-  def testValidate_buildingConfigEntityWithId_Success(self):
+  def testValidate_BuildingConfigEntityWithId_Success(self):
     parsed, default_operation = _Helper(
         [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
     entity_iter = iter(parsed.items())
@@ -1055,7 +1055,7 @@ class EntityInstanceTest(absltest.TestCase):
     self.assertFalse(entity_instance.IsEntityIdPresent(entity_1))
     self.assertTrue(self.init_validator.Validate(entity_2))
     self.assertTrue(entity_instance.IsEntityIdPresent(entity_2))
-    self.assertEqual(entity_2._id,
+    self.assertEqual(entity_2.entity_id,
         parsed['UK-LON-S2-GUID'].get(instance_parser.ENTITY_ID_KEY))
 
 if __name__ == '__main__':

--- a/tools/validators/instance_validator/tests/fake_instances/GOOD/bc_entity_with_id.yaml
+++ b/tools/validators/instance_validator/tests/fake_instances/GOOD/bc_entity_with_id.yaml
@@ -15,7 +15,6 @@
 # Test entity with ids
 
 DMP_EDM-17-GUID:
-  id: "deprecated but doesn't break"
   type: HVAC/DMP_EDM
   code: DMP_EDM-17
   cloud_device_id: "foobar"
@@ -32,5 +31,6 @@ DMP_EDM-17-GUID:
         CLOSED: "0"
 
 UK-LON-S2-GUID:
+  id: "deprecated-but-doesn't-break"
   type: FACILITIES/BUILDING
   code: UK-LON-S2

--- a/tools/validators/instance_validator/tests/fake_instances/GOOD/bc_entity_with_id.yaml
+++ b/tools/validators/instance_validator/tests/fake_instances/GOOD/bc_entity_with_id.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test entity with ids
+
+DMP_EDM-17-GUID:
+  id: "deprecated but doesn't break"
+  type: HVAC/DMP_EDM
+  code: DMP_EDM-17
+  cloud_device_id: "foobar"
+  translation:
+    exhaust_air_damper_command:
+      present_value: "points.exhaust_air_damper_command.present_value"
+      states:
+        OPEN: "1"
+        CLOSED: "0"
+    exhaust_air_damper_status:
+      present_value: "points.exhaust_air_damper_status.present_value"
+      states:
+        OPEN: "1"
+        CLOSED: "0"
+
+UK-LON-S2-GUID:
+  type: FACILITIES/BUILDING
+  code: UK-LON-S2

--- a/tools/validators/instance_validator/tests/instance_parser_test.py
+++ b/tools/validators/instance_validator/tests/instance_parser_test.py
@@ -246,7 +246,7 @@ class ParserTest(absltest.TestCase):
     self.assertLen(parser.GetEntities().keys(), 1)
     self.assertEqual(parser.GetEntities(), expected)
 
-  def testGoodEntityDefaultExportOperationParses_Success(self):
+  def testGoodEntity_DefaultExportOperationParses_Success(self):
     parser = _ParserHelper(
         [path.join(_TESTCASE_PATH, 'GOOD', 'entity_export_operation.yaml')])
 
@@ -270,6 +270,20 @@ class ParserTest(absltest.TestCase):
       parser = _Helper(
           [path.join(_TESTCASE_PATH, 'BAD', 'update_mask_operation.yaml')])
       del parser
+
+def testGoodBuildingConfig_entityWithId_Success(self):
+    parser = _ParserHelper(
+        [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
+
+    parsed = parser.GetEntities()
+    _, entity = next(iter(parsed.items()))
+    entity_operation = entity.get(instance_parser.ENTITY_OPERATION_KEY, None)
+    default_operation = handler.GetDefaultOperation(parser.GetConfigMode())
+
+    self.assertIsNone(entity_operation)
+    self.assertLen(parser.GetEntities().keys(), 2)
+    self.assertEqual(entity.get(instance_parser.ENTITY_ID_KEY),
+        "deprecated but doesn't break")
 
 if __name__ == '__main__':
   absltest.main()

--- a/tools/validators/instance_validator/tests/instance_parser_test.py
+++ b/tools/validators/instance_validator/tests/instance_parser_test.py
@@ -276,10 +276,13 @@ class ParserTest(absltest.TestCase):
         [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
 
     parsed = parser.GetEntities()
-    _, entity = next(next(iter(parsed.items())))
+    iterator = iter(parsed.items())
+    _, entity_1 = next(iterator)
+    _, entity_2 = next(iterator)
 
     self.assertLen(parser.GetEntities().keys(), 2)
-    self.assertEqual(entity.get(instance_parser.ENTITY_ID_KEY),
+    self.assertIsNone(entity_1.get(instance_parser.ENTITY_ID_KEY))
+    self.assertEqual(entity_2.get(instance_parser.ENTITY_ID_KEY),
         "deprecated-but-doesn't-break")
 
 if __name__ == '__main__':

--- a/tools/validators/instance_validator/tests/instance_parser_test.py
+++ b/tools/validators/instance_validator/tests/instance_parser_test.py
@@ -277,10 +277,7 @@ def testGoodBuildingConfig_entityWithId_Success(self):
 
     parsed = parser.GetEntities()
     _, entity = next(next(iter(parsed.items())))
-    entity_operation = entity.get(instance_parser.ENTITY_OPERATION_KEY, None)
-    default_operation = handler.GetDefaultOperation(parser.GetConfigMode())
 
-    self.assertIsNone(entity_operation)
     self.assertLen(parser.GetEntities().keys(), 2)
     self.assertEqual(entity.get(instance_parser.ENTITY_ID_KEY),
         "deprecated-but-doesn't-break")

--- a/tools/validators/instance_validator/tests/instance_parser_test.py
+++ b/tools/validators/instance_validator/tests/instance_parser_test.py
@@ -271,16 +271,16 @@ class ParserTest(absltest.TestCase):
           [path.join(_TESTCASE_PATH, 'BAD', 'update_mask_operation.yaml')])
       del parser
 
-def testEntityBlock_EntityWithId_Success(self):
-  parser = _ParserHelper(
-      [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
+  def testEntityBlock_EntityWithId_Success(self):
+    parser = _ParserHelper(
+        [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
 
-  parsed = parser.GetEntities()
-  _, entity = next(next(iter(parsed.items())))
+    parsed = parser.GetEntities()
+    _, entity = next(next(iter(parsed.items())))
 
-  self.assertLen(parser.GetEntities().keys(), 2)
-  self.assertEqual(entity.get(instance_parser.ENTITY_ID_KEY),
-      "deprecated-but-doesn't-break")
+    self.assertLen(parser.GetEntities().keys(), 2)
+    self.assertEqual(entity.get(instance_parser.ENTITY_ID_KEY),
+        "deprecated-but-doesn't-break")
 
 if __name__ == '__main__':
   absltest.main()

--- a/tools/validators/instance_validator/tests/instance_parser_test.py
+++ b/tools/validators/instance_validator/tests/instance_parser_test.py
@@ -271,7 +271,7 @@ class ParserTest(absltest.TestCase):
           [path.join(_TESTCASE_PATH, 'BAD', 'update_mask_operation.yaml')])
       del parser
 
-def testGoodBuildingConfig_EntityWithId_Success(self):
+def testEntityBlock_EntityWithId_Success(self):
   parser = _ParserHelper(
       [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
 

--- a/tools/validators/instance_validator/tests/instance_parser_test.py
+++ b/tools/validators/instance_validator/tests/instance_parser_test.py
@@ -276,14 +276,14 @@ def testGoodBuildingConfig_entityWithId_Success(self):
         [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
 
     parsed = parser.GetEntities()
-    _, entity = next(iter(parsed.items()))
+    _, entity = next(next(iter(parsed.items())))
     entity_operation = entity.get(instance_parser.ENTITY_OPERATION_KEY, None)
     default_operation = handler.GetDefaultOperation(parser.GetConfigMode())
 
     self.assertIsNone(entity_operation)
     self.assertLen(parser.GetEntities().keys(), 2)
     self.assertEqual(entity.get(instance_parser.ENTITY_ID_KEY),
-        "deprecated but doesn't break")
+        "deprecated-but-doesn't-break")
 
 if __name__ == '__main__':
   absltest.main()

--- a/tools/validators/instance_validator/tests/instance_parser_test.py
+++ b/tools/validators/instance_validator/tests/instance_parser_test.py
@@ -272,15 +272,15 @@ class ParserTest(absltest.TestCase):
       del parser
 
 def testGoodBuildingConfig_EntityWithId_Success(self):
-    parser = _ParserHelper(
-        [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
+  parser = _ParserHelper(
+      [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
 
-    parsed = parser.GetEntities()
-    _, entity = next(next(iter(parsed.items())))
+  parsed = parser.GetEntities()
+  _, entity = next(next(iter(parsed.items())))
 
-    self.assertLen(parser.GetEntities().keys(), 2)
-    self.assertEqual(entity.get(instance_parser.ENTITY_ID_KEY),
-        "deprecated-but-doesn't-break")
+  self.assertLen(parser.GetEntities().keys(), 2)
+  self.assertEqual(entity.get(instance_parser.ENTITY_ID_KEY),
+      "deprecated-but-doesn't-break")
 
 if __name__ == '__main__':
   absltest.main()

--- a/tools/validators/instance_validator/tests/instance_parser_test.py
+++ b/tools/validators/instance_validator/tests/instance_parser_test.py
@@ -271,7 +271,7 @@ class ParserTest(absltest.TestCase):
           [path.join(_TESTCASE_PATH, 'BAD', 'update_mask_operation.yaml')])
       del parser
 
-def testGoodBuildingConfig_entityWithId_Success(self):
+def testGoodBuildingConfig_EntityWithId_Success(self):
     parser = _ParserHelper(
         [path.join(_TESTCASE_PATH, 'GOOD', 'bc_entity_with_id.yaml')])
 

--- a/tools/validators/instance_validator/validate/entity_instance.py
+++ b/tools/validators/instance_validator/validate/entity_instance.py
@@ -512,9 +512,12 @@ class InstanceValidator(object):
     Returns:
       True if the entity is valid
     """
-    if IsEntityIdPresent(entity):
-      print('Warning: Entity id detected in block. Planned depre')
 
+    if IsEntityIdPresent(entity):
+      print('Warning: Entity id detected in block. Planned deprecation, ',
+        'will result in validation error in a future releases. Please ',
+        'review digitalbuildings/ontology/docs/building_config.md for ',
+        'more info')
 
     is_valid = True
 

--- a/tools/validators/instance_validator/validate/entity_instance.py
+++ b/tools/validators/instance_validator/validate/entity_instance.py
@@ -214,6 +214,10 @@ class GraphValidator(object):
     return is_valid
 
 
+def IsEntityIdPresent(entity: EntityInstance) -> bool:
+  return entity._id is not None
+
+
 class InstanceValidator(object):
   """Class to support validation of intra-entity rules in config.
 
@@ -508,6 +512,10 @@ class InstanceValidator(object):
     Returns:
       True if the entity is valid
     """
+    if IsEntityIdPresent(entity):
+      print('Warning: Entity id detected in block. Planned depre')
+
+
     is_valid = True
 
     if entity.update_mask is not None:
@@ -726,6 +734,7 @@ class EntityInstance(findings_lib.Findings):
                connections=None,
                links=None,
                etag=None,
+               _id=None,
                update_mask=None):
     super().__init__()
 
@@ -738,8 +747,9 @@ class EntityInstance(findings_lib.Findings):
     self.translation = translation
     self.connections = connections
     self.links = links
-    self.update_mask = update_mask
     self.etag = etag
+    self._id = _id
+    self.update_mask = update_mask
 
   @classmethod
   def FromYaml(
@@ -841,6 +851,11 @@ class EntityInstance(findings_lib.Findings):
     etag = None
     if parse.ETAG_KEY in entity_yaml:
       etag = entity_yaml[parse.ETAG_KEY]
+    
+    # deprecated; kept for legacy reasons
+    _id = None
+    if parse.ENTITY_ID_KEY in entity_yaml:
+      _id = entity_yaml[parse.ENTITY_ID_KEY]
 
     return cls(
         operation,
@@ -853,4 +868,5 @@ class EntityInstance(findings_lib.Findings):
         connections=connections,
         links=links,
         etag=etag,
+        _id=_id,
         update_mask=update_mask)

--- a/tools/validators/instance_validator/validate/entity_instance.py
+++ b/tools/validators/instance_validator/validate/entity_instance.py
@@ -215,7 +215,7 @@ class GraphValidator(object):
 
 
 def IsEntityIdPresent(entity: EntityInstance) -> bool:
-  return entity._id is not None
+  return entity.entity_id is not None
 
 
 class InstanceValidator(object):
@@ -737,7 +737,7 @@ class EntityInstance(findings_lib.Findings):
                connections=None,
                links=None,
                etag=None,
-               _id=None,
+               entity_id=None,
                update_mask=None):
     super().__init__()
 
@@ -751,7 +751,7 @@ class EntityInstance(findings_lib.Findings):
     self.connections = connections
     self.links = links
     self.etag = etag
-    self._id = _id
+    self.entity_id = entity_id
     self.update_mask = update_mask
 
   @classmethod
@@ -854,11 +854,11 @@ class EntityInstance(findings_lib.Findings):
     etag = None
     if parse.ETAG_KEY in entity_yaml:
       etag = entity_yaml[parse.ETAG_KEY]
-    
+
     # deprecated; kept for legacy reasons
-    _id = None
+    entity_id = None
     if parse.ENTITY_ID_KEY in entity_yaml:
-      _id = entity_yaml[parse.ENTITY_ID_KEY]
+      entity_id = entity_yaml[parse.ENTITY_ID_KEY]
 
     return cls(
         operation,
@@ -871,5 +871,5 @@ class EntityInstance(findings_lib.Findings):
         connections=connections,
         links=links,
         etag=etag,
-        _id=_id,
+        entity_id=entity_id,
         update_mask=update_mask)

--- a/tools/validators/instance_validator/validate/instance_parser.py
+++ b/tools/validators/instance_validator/validate/instance_parser.py
@@ -103,6 +103,7 @@ def _MergeSchemas(first: Dict[syaml.ScalarValidator, syaml.Validator],
 
 
 #### Public Text parsing Constants ####
+ENTITY_ID_KEY = 'id'  # deprecated; kept for legacy reasons
 ENTITY_GUID_KEY = 'guid'
 ENTITY_CODE_KEY = 'code'
 ENTITY_CLOUD_DEVICE_ID_KEY = 'cloud_device_id'
@@ -183,6 +184,9 @@ _ENTITY_IDS_SCHEMA = {
         syaml.Str(),
     # this is the numeric cloud device id from Cloud IoT
     syaml.Optional(ENTITY_CLOUD_DEVICE_ID_KEY):
+        syaml.Str(),
+    # this is deprecated; kept for legacy reasons
+    syaml.Optional(ENTITY_ID_KEY):
         syaml.Str(),
 }
 _ENTITY_ATTRIB_SCHEMA = {


### PR DESCRIPTION
we require that building configuration validation accept entities with an 'id' attribute; validating the entity along with a warning to the user regarding planned deprecation.

changes:
1. instance_parser.py
  - include constant ENTITY_ID_KEY
  - include strictyaml validator to _ENTITY_IDS_SCHEMA for ENTITY_ID_KEY
 2. entity_instance.py
  - include _id attribute to EntityInstance class along with fromYaml (overload init)
  - include function IsEntityIdPresent(entity: EntityInstance) -> bool

and associated tests with the inclusion of bc_entity_with_id.yaml in fake_instances/GOOD 