### PR TITLE
Add default ontology path to silence ontology validator warnings

### DIFF
--- a/tools/abel/abel.py
+++ b/tools/abel/abel.py
@@ -81,8 +81,8 @@ def _spreadsheet_workflow(spreadsheet_id: str,
     print('Validating Export.')
     handler.RunValidation(
         filenames=[BC_EXPORT_PATH],
-        report_filename=INSTANCE_VALIDATOR_LOG_PATH,
-        modified_types_filepath=ontology_path,
+        report_filename=INSTANCE_VALIDATOR_LOG_PATH
+        default_types_filepath=ontology_path,
         subscription=subscription,
         service_account=service_account,
         timeout=timeout
@@ -110,7 +110,7 @@ def _bc_workflow(spreadsheet_id: str,
   handler.RunValidation(
       filenames=[bc_filepath],
       report_filename=INSTANCE_VALIDATOR_LOG_PATH,
-      modified_types_filepath=ontology_path
+      default_types_filepath=ontology_path
   )
   print(f'Importing Building Configuration file from {bc_filepath}.')
   imported_building_config = import_helper.DeserializeBuildingConfiguration(

--- a/tools/validators/instance_validator/validate/generate_universe.py
+++ b/tools/validators/instance_validator/validate/generate_universe.py
@@ -28,6 +28,7 @@ from yamlformat.validator import presubmit_validate_types_lib
 def BuildUniverse(
     use_simplified_universe: bool = False,
     modified_types_filepath: str = None,
+    default_types_filepath: str = constants.ONTOLOGY_ROOT,
 ) -> presubmit_validate_types_lib.ConfigUniverse:
   """Generates the ontology universe.
 
@@ -54,17 +55,17 @@ def BuildUniverse(
     external_file_lib.Validate(
         filter_text=None,
         changed_directory=modified_types_filepath,
-        original_directory=constants.ONTOLOGY_ROOT,
+        original_directory=default_types_filepath,
         interactive=False)
     yaml_files = external_file_lib.RecursiveDirWalk(modified_types_filepath)
   else:
-    default_ontology_exists = path.exists(constants.ONTOLOGY_ROOT)
+    default_ontology_exists = path.exists(default_types_filepath)
     if not default_ontology_exists:
       print(f'Specified filepath [{constants.ONTOLOGY_ROOT}] '
             'for default ontology does not exist')
       return None
     # use default location for ontology files
-    yaml_files = external_file_lib.RecursiveDirWalk(constants.ONTOLOGY_ROOT)
+    yaml_files = external_file_lib.RecursiveDirWalk(default_types_filepath)
 
   if yaml_files:
     config = presubmit_validate_types_lib.SeparateConfigFiles(yaml_files)

--- a/tools/validators/instance_validator/validate/handler.py
+++ b/tools/validators/instance_validator/validate/handler.py
@@ -100,6 +100,7 @@ def _ValidateTelemetry(subscription: str, service_account: str,
 def RunValidation(filenames: List[str],
                   use_simplified_universe: bool = False,
                   modified_types_filepath: str = None,
+                  default_types_filepath: str = None,
                   subscription: str = None,
                   service_account: str = None,
                   report_filename: str = None,
@@ -115,9 +116,11 @@ def RunValidation(filenames: List[str],
   try:
     print('\nStarting validator...\n')
     print('\nStarting universe generation...\n')
+    print(f'DEFAULT TYPES PATH: {default_types_filepath}')
     universe = generate_universe.BuildUniverse(
         use_simplified_universe=use_simplified_universe,
-        modified_types_filepath=modified_types_filepath)
+        modified_types_filepath=modified_types_filepath,
+        default_types_filepath=default_types_filepath)
     if not universe:
       print('\nError generating universe')
       sys.exit(0)


### PR DESCRIPTION
Silences ontology validator warnings AND speeds up instance validation since the default ontology is not being validated. A two-fer!