### PR TITLE
Update README.md to include bash for pip_install.sh script

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -35,7 +35,7 @@ Then you can either use pip or setuptools.
 ### Pip
 1. Run `python3 -m pip install --upgrade pip` to ensure that your Python package management tools are up-to-date.
 
-2. Run `pip_install.sh` or `pip_install.bat` (windows) from the following directory digitalbuildings/tools.
+2. Run `bash pip_install.sh` or `pip_install.bat` (windows) from the following directory digitalbuildings/tools.
 
 
 


### PR DESCRIPTION
The `shopt` command is only accessible from the `bash` shell on linux systems.