### PR TITLE
Update Windows pip install to use Python3

### DIFF
--- a/tools/pip_install.bat
+++ b/tools/pip_install.bat
@@ -4,28 +4,28 @@ ECHO "Starting setup..."
 :ontology_validator_setup
 ECHO "Starting ontology validator setup"
 CD validators\ontology_validator
-START python3 -m pip install .
+START python -m pip install .
 ECHO "Finished ontology validator setup"
 CD ..\..\
 
 :instance_validator_setup
 ECHO "Starting instance validator setup"
 CD validators\instance_validator
-START python3 -m pip install .
+START python -m pip install .
 ECHO "Finished instance validator setup"
 CD ..\..
 
 :guid_generator_setup
 ECHO "Starting GUID generator setup"
 CD guid_generator
-START python3 -m pip install .
+START python -m pip install .
 ECHO "Finished GUID generator setup"
 CD ..
 
 :abel_setup
 ECHO "Starting ABEL setup"
 CD abel
-START python3 -m pip install .
+START python -m pip install .
 ECHO "Finished ABEL setup"
 CD ..
 

--- a/tools/pip_install.bat
+++ b/tools/pip_install.bat
@@ -4,28 +4,28 @@ ECHO "Starting setup..."
 :ontology_validator_setup
 ECHO "Starting ontology validator setup"
 CD validators\ontology_validator
-START py -m pip install .
+START python3 -m pip install .
 ECHO "Finished ontology validator setup"
 CD ..\..\
 
 :instance_validator_setup
 ECHO "Starting instance validator setup"
 CD validators\instance_validator
-START py -m pip install .
+START python3 -m pip install .
 ECHO "Finished instance validator setup"
 CD ..\..
 
 :guid_generator_setup
 ECHO "Starting GUID generator setup"
 CD guid_generator
-START py -m pip install .
+START python3 -m pip install .
 ECHO "Finished GUID generator setup"
 CD ..
 
 :abel_setup
 ECHO "Starting ABEL setup"
 CD abel
-START py -m pip install .
+START python3 -m pip install .
 ECHO "Finished ABEL setup"
 CD ..
 


### PR DESCRIPTION
Using `py -m pip install .` seems to behave differently than `python3 -m pip install .` and doesn't install packages in the correct location. This should fix that.