### PR TITLE
Links fix for ABEL docs

### DIFF
--- a/tools/abel/README.md
+++ b/tools/abel/README.md
@@ -205,7 +205,7 @@ python3 abel.py -s <input_spreadsheet_id>
 The process for using a building config to generate an ABEL spreadsheet is as
 follows:
 
-1. Create a blank spreadsheet for ABEL to write to from [ABEL Spreadsheet template](https://docs.google.com/spreadsheets/d/1tcLjFnHiXUT-xh5C1hRKiUVaUH_CzgSI8zFQ_B8q7vs/copy#gid=980240783)
+1. Create a blank spreadsheet for ABEL to write to from [ABEL Spreadsheet template](https://docs.google.com/spreadsheets/d/1b6IRimNS1dAtPjkNN-fk4TirnLzOiDyyUmOKP_MhMM0/copy?usp=sharing)
 2. Share your spreadsheet with your GCP service account and project id as an editor. Refer to Google Sheets documentation on [how to share a google sheet](https://support.google.com/docs/answer/9331169?hl=en#6.1).
 3. In `digitalbuildings/tools/abel` run ABEL with the command:
 ```


### PR DESCRIPTION
Found an outdated link in the docs.