### PR TITLE
Reduce time to run scoring tool tests

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -40,10 +40,10 @@ jobs:
             - 'tools/validators/ontology_validator/**'
           scoring:
             - 'tools/scoring/**'
-    - name: Set up Python 3.10
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: 3.9
     - name: Install Pylint
       run: |
         python -m pip install pylint

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -40,10 +40,10 @@ jobs:
             - 'tools/validators/ontology_validator/**'
           scoring:
             - 'tools/scoring/**'
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
       with:
-        python-version: 3.11.0
+        python-version: 3.11
     - name: Install Pylint
       run: |
         python -m pip install pylint

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10.8
+        python-version: 3.11.0
     - name: Install Pylint
       run: |
         python -m pip install pylint

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -40,10 +40,10 @@ jobs:
             - 'tools/validators/ontology_validator/**'
           scoring:
             - 'tools/scoring/**'
-    - name: Set up Python 3.10.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10.9
+        python-version: 3.10
     - name: Install Pylint
       run: |
         python -m pip install pylint

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -40,10 +40,10 @@ jobs:
             - 'tools/validators/ontology_validator/**'
           scoring:
             - 'tools/scoring/**'
-    - name: Set up Python 3.11
+    - name: Set up Python 3.10.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.11
+        python-version: 3.10.9
     - name: Install Pylint
       run: |
         python -m pip install pylint

--- a/tools/scoring/tests/complete_output_test.py
+++ b/tools/scoring/tests/complete_output_test.py
@@ -19,7 +19,9 @@ from score import parse_config
 
 
 class CompleteOutputTest(absltest.TestCase):
-  def setUp(self):
+
+  @classmethod
+  def setUpClass(self):
     super().setUp()
     ontolgy = '../../ontology/yaml/resources'
     proposed = 'tests/samples/proposed/real_world_proposed.yaml'

--- a/tools/scoring/tests/complete_output_test.py
+++ b/tools/scoring/tests/complete_output_test.py
@@ -31,7 +31,7 @@ class CompleteOutputTest(absltest.TestCase):
     scorer = parse_config.ParseConfig(ontology=ontolgy,
                                       proposed=proposed,
                                       solution=solution)
-    self.output = scorer.execute()
+    cls.output = scorer.execute()
 
   def testEntityConnectionIdentification(self):
     score = self.output['EntityConnectionIdentification']

--- a/tools/scoring/tests/complete_output_test.py
+++ b/tools/scoring/tests/complete_output_test.py
@@ -22,7 +22,7 @@ class CompleteOutputTest(absltest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    super().setUp()
+    super().setUpClass()
     ontolgy = '../../ontology/yaml/resources'
     proposed = 'tests/samples/proposed/real_world_proposed.yaml'
     solution = 'tests/samples/solution/real_world_solution.yaml'

--- a/tools/scoring/tests/complete_output_test.py
+++ b/tools/scoring/tests/complete_output_test.py
@@ -21,7 +21,7 @@ from score import parse_config
 class CompleteOutputTest(absltest.TestCase):
 
   @classmethod
-  def setUpClass(self):
+  def setUpClass(cls):
     super().setUp()
     ontolgy = '../../ontology/yaml/resources'
     proposed = 'tests/samples/proposed/real_world_proposed.yaml'


### PR DESCRIPTION
For every test, the scorer builds the ontology from scratch. This can be remedied by using the setUpClass() function to run setup only once.