### PR TITLE
Change test setup to decrease testing time

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10.8
+        python-version: '3.10'
     - name: Install Pylint
       run: |
         python -m pip install pylint

--- a/tools/scoring/tests/complete_output_test.py
+++ b/tools/scoring/tests/complete_output_test.py
@@ -19,6 +19,8 @@ from score import parse_config
 
 
 class CompleteOutputTest(absltest.TestCase):
+
+  @classmethod
   def setUpClass(cls):
     super().setUpClass()
     ontolgy = '../../ontology/yaml/resources'

--- a/tools/scoring/tests/complete_output_test.py
+++ b/tools/scoring/tests/complete_output_test.py
@@ -19,8 +19,8 @@ from score import parse_config
 
 
 class CompleteOutputTest(absltest.TestCase):
-  def setUp(self):
-    super().setUp()
+  def setUpClass(cls):
+    super().setUpClass()
     ontolgy = '../../ontology/yaml/resources'
     proposed = 'tests/samples/proposed/real_world_proposed.yaml'
     solution = 'tests/samples/solution/real_world_solution.yaml'
@@ -29,7 +29,7 @@ class CompleteOutputTest(absltest.TestCase):
     scorer = parse_config.ParseConfig(ontology=ontolgy,
                                       proposed=proposed,
                                       solution=solution)
-    self.output = scorer.execute()
+    cls.output = scorer.execute()
 
   def testEntityConnectionIdentification(self):
     score = self.output['EntityConnectionIdentification']

--- a/tools/scoring/tests/parse_config_test.py
+++ b/tools/scoring/tests/parse_config_test.py
@@ -32,14 +32,16 @@ SIMPLE, COMPLEX = DimensionCategories
 
 
 class ParseConfigTest(absltest.TestCase):
-  def setUp(self):
-    super().setUp()
-    self.ontology = '../../ontology/yaml/resources'
-    self.solution = 'tests/samples/solution/building_config_example.yaml'
-    self.proposed = 'tests/samples/proposed/building_config_example.yaml'
-    self.parse = parse_config.ParseConfig(ontology=self.ontology,
-                                          solution=self.solution,
-                                          proposed=self.proposed)
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    cls.ontology = '../../ontology/yaml/resources'
+    cls.solution = 'tests/samples/solution/building_config_example.yaml'
+    cls.proposed = 'tests/samples/proposed/building_config_example.yaml'
+    cls.parse = parse_config.ParseConfig(ontology=cls.ontology,
+                                          solution=cls.solution,
+                                          proposed=cls.proposed)
 
   def testInitialize(self):
     self.assertEqual(self.parse.args['ontology'], self.ontology)


### PR DESCRIPTION
Change `setUp()` to `setUpClass` for testing classes that build the ontology. This makes it so the ontology is not built for every test and is instead just built once for the entire class.

See: 
- https://abseil.io/docs/python/guides/testing
- https://stackoverflow.com/questions/23667610/what-is-the-difference-between-setup-and-setupclass-in-python-unittest