### PR TITLE
Fix various typos and repair LICENSE to fit standards.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,14 +29,13 @@ This project follows
 
 ## Pull requests
 
-If you are Google partner, please make sure not to add sensitive data on github when:
+If you are Google partner, please make sure not to add sensitive data on GitHub when:
 * Extending the ontology types through a pull request 
 * Opening an issue
 * Asking a question
 
 Sensitive data is one of the following:
 * Building names or their locations, same applied for floors, rooms and zones.
-* Indentifiers such as project id, subscription names
+* Identifiers such as project id, subscription names
 * Equipment names and their locations.
 * Others
-

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-```
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023 Google LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -201,4 +200,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-```

--- a/ibr/ibr_sdk/README.md
+++ b/ibr/ibr_sdk/README.md
@@ -1,6 +1,6 @@
 # IBR Javascript SDK
 
-This purpose of this project is to allow developers to seemlessly work with CAD-like building data. This library allows users to seamlessly work with ibr data in javascript as well as provides built in methods to create a simple UI built on [THREE.js](https://github.com/mrdoob/three.js/)
+This purpose of this project is to allow developers to seamlessly work with CAD-like building data. This library allows users to seamlessly work with ibr data in javascript as well as provides built in methods to create a simple UI built on [THREE.js](https://github.com/mrdoob/three.js/)
 
 ## Instructions for Running the IBR UI:
 

--- a/ibr/png_parser/README.md
+++ b/ibr/png_parser/README.md
@@ -4,7 +4,7 @@
     - Check if you have Bazel installed already using command `bazel --version`.
     - If no version number is shown, follow instruction [here](https://docs.bazel.build/versions/master/install.html).
 
-2. Compile the proto definition to python classes(Note: the compiled proto definition is already included in this repo. These instructures are only for your reference in case you would like to compiler your own proto definition.)
+2. Compile the proto definition to python classes(Note: the compiled proto definition is already included in this repo. These instructions are only for your reference in case you would like to compile your own proto definition.)
 	- move to current directory `cd digitalbuildings/ibr/png-parser`
 	- Install latest release of Protocol Compiler
 	    - Go to [Download Protocol Compiler](https://developers.google.com/protocol-buffers/docs/downloads)

--- a/ontology/README.md
+++ b/ontology/README.md
@@ -9,8 +9,8 @@ The model is provided in two versions:
 Documentation for the model can be found in the [docs](docs/) folder.  
 *   [Ontology Overview](/ontology/docs/ontology.md) provides an overview of the structure and first principles of the ontology
 *   [Ontology Configuration](/ontology/docs/ontology_config.md) explains how to write and validate the .yaml configuration files
-*   [Model](/ontology/docs/model.md) describes the convcentions used in the provided abstract model
-*   [Building Configuration](/ontology/docs/building_config.md) describes the confguration format for mapping concrete assets to a model and 
+*   [Model](/ontology/docs/model.md) describes the conventions used in the provided abstract model
+*   [Building Configuration](/ontology/docs/building_config.md) describes the configuration format for mapping concrete assets to a model and 
 validating the mapping
 
 ## Learning Modules
@@ -47,7 +47,5 @@ In this module, you’ll deepen your understanding of the DBO and practice apply
 * [Lesson 5: Propose an ontology extension](./docs/learning/Module_2_Lesson_5_Propose_an_ontology_extension.pdf)
 * [Lesson 6: Construct and finalize the building configuration file](./docs/learning/Module_2_Lesson_6_Construct_and_finalize_the_building_configuration_file.pdf)
 * [Lesson 7: Validate the instance and telemetry](./docs/learning/Module_2_Lesson_7_Validate_the_instance_and_telemetry.pdf)
-
-
 
 Enjoy!

--- a/ontology/docs/building_config.md
+++ b/ontology/docs/building_config.md
@@ -400,7 +400,7 @@ FCU-123:
 ```
 --->
 <!--
-** metadata has not been implemented as of yet; this is an addition
+** metadata has not been implemented yet; this is an addition
    due to ABEL **
 ##### Metadata
 
@@ -524,7 +524,7 @@ grouped into two mutually exclusive parts:
    entities contained in the building configuration.
 
 2. Entity block(s) derived from a physical building; they model physical and
-   [virtual devices](#virutal-devices) within a building. For more information
+   [virtual devices](#virtual-devices) within a building. For more information
    please refer to the [learning modules](../../README.md#learning-modules).
 
 The configuration block, keyed by `CONFIG_METADATA`, currently allows for

--- a/ontology/docs/faq.md
+++ b/ontology/docs/faq.md
@@ -47,7 +47,7 @@ It does not have to be translated into the model, but for extensibility purposes
 ## What device data should be modeled?
 **Model what you need for the applications and analytics that are reasonably anticipated.** 
 
-More data can always be added later (as long as it’s exposed in the gateway). The general rule is to model things that describe the device’s general behavior without superfluous detail regarding its low-level configuration; however, anything can be modeled, so if need arises then the ontology can be extended to accommodate. There are a few types of data that devices typically sends:
+More data can always be added later (as long as it’s exposed in the gateway). The general rule is to model things that describe the device’s general behavior without superfluous detail regarding its low-level configuration; however, anything can be modeled, so if the need arises then the ontology can be extended to accommodate. There are a few types of data that devices typically sends:
 
 ### Measured Telemetry
 These are sensors associated with the device, such as `supply_air_temperature_sensor` and `chilled_water_valve_percentage_sensor`. They are directly measured (or calculated) by the device and return updated values as the state of the device changes through time. All measured telemetry is normally modeled. *NOTE: we do not consider calculated telemetry differently from raw telemetry.*
@@ -67,7 +67,7 @@ These are internal device points which are used to configure the way in which th
 ## Should alarms or faults be modeled?
 **No, unless there is an explicit need to do so.**
 
-Most alarms can be inferred from the sensor data already available (e.g. `supply_fan_run_command` == ON and `supply_fan_run_status` == OFF shows a fan failure, so an additional point that does that inferrence is redundant). Redundancy should always be minimized.
+Most alarms can be inferred from the sensor data already available (e.g. `supply_fan_run_command` == ON and `supply_fan_run_status` == OFF shows a fan failure, so an additional point that does that inference is redundant). Redundancy should always be minimized.
 
 ## How do you extend the ontology?
 **This depends on what needs to be extended.** 

--- a/ontology/docs/hvac_ahu.md
+++ b/ontology/docs/hvac_ahu.md
@@ -204,7 +204,7 @@ VAV-1:
 ```
 
 ## Optional And Future Extensions
-This section contains some additional features and extensions that could be added in future.
+This section contains some additional features and extensions that could be added in the future.
 - While hydronic systems tie equipment together via an explicitly defined entity (the system itself), there is no such concept in the ontology for air-side systems, at least today. This could be added to help describe convoluted systems.
 - Risers do exist in the ontology but are utilized only when data exists specifically for that riser (necessitating the entity) or when the system is convoluted enough to justify it. It is best to omit this type of addition, excepting circumstances where it is absolutely necessary.
 

--- a/ontology/docs/hvac_chws.md
+++ b/ontology/docs/hvac_chws.md
@@ -132,7 +132,7 @@ This version of CHWS has a single set of variable speed chilled water pumps serv
 ### BMS Example
 ![CHWS Variable Primary WC](./figures/bms_screenshots/chws_watercooled.png)
 **Notes:**
-- This example includes a parallel air-cooled chiller. It is simple enough to add; it doesnt change the way the rest of the system is modeled.
+- This example includes a parallel air-cooled chiller. It is simple enough to add; it doesn't change the way the rest of the system is modeled.
 
 ### System Diagram and Connections
 ![CHWS Variable Primary WC](./figures/system_diagrams/chws_watercooled.png)

--- a/ontology/docs/model_hvac.md
+++ b/ontology/docs/model_hvac.md
@@ -151,11 +151,11 @@ application and provides basic guidelines for constructing new types.
 
 ### General Types
 
-The concept of an **general type** (see
+The concept of a **general type** (see
 [general types](model.md#general-types) for model details) is used to broadly
 classify equipment based on its holistic function. Because types with very
 similar function (such as fans or AHUs) can be extremely varied, it is important
-to have an general concept that allows *similar enough* devices to be
+to have a general concept that allows *similar enough* devices to be
 considered together, even when their specific type definitions otherwise
 wouldn’t strongly group them.
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,7 +10,7 @@ To install please follow the instructions below.
 
 ### First create a virtual env
 
-Create the virutal environment with `virtualenv` followed by the environment name, in this example: `tooling`
+Create the virtual environment with `virtualenv` followed by the environment name, in this example: `tooling`
 
 ```
 virtualenv tooling

--- a/tools/abel/README.md
+++ b/tools/abel/README.md
@@ -19,7 +19,7 @@ Before starting the setup and installation process, please ensure that the
 dependencies are met:
 1. You are running **Python 3.9** or higher
 3. You have installed [virtualenv](https://pypi.org/project/virtualenv/)
-2. you have installed the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)
+2. You have installed the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)
 
 ### Set up a tooling environment
 

--- a/tools/abel/model/export_helper.py
+++ b/tools/abel/model/export_helper.py
@@ -187,7 +187,7 @@ class BuildingConfigExport(object):
     """Returns a Building Config formatted virtual entity block dictionary.
 
     Args:
-      entity: A VirutalEntity instance.
+      entity: A VirtualEntity instance.
 
     Returns:
       A dicitionary formatted for Building Config ready to be parsed into yaml.

--- a/tools/abel/validators/README.md
+++ b/tools/abel/validators/README.md
@@ -90,7 +90,7 @@ Cloud registry [device numeric identifier](../../../ontology/docs/building_confi
 
 `DBO Namespace` *string* **required**
 
-[Namespace](../../../ontology/docs/ontology.md#namespaces) for an entity as defined in the [Digital Buidings Ontology](../../../ontology/README.md). e.g. `HVAC`
+[Namespace](../../../ontology/docs/ontology.md#namespaces) for an entity as defined in the [Digital Buildings Ontology](../../../ontology/README.md). e.g. `HVAC`
 
 `DBO General Type` *string*
 

--- a/tools/explorer/README.md
+++ b/tools/explorer/README.md
@@ -11,7 +11,7 @@ To install please follow the instructions below.
 
 ## First create a virtual env
 
-Create the virutal environment with `virtualenv` followed by the environment name, in this example: `tooling`
+Create the virtual environment with `virtualenv` followed by the environment name, in this example: `tooling`
 
 ```
 virtualenv tooling

--- a/tools/guid_generator/README.md
+++ b/tools/guid_generator/README.md
@@ -13,7 +13,7 @@ To install please follow the instructions below.
 
 ## First create a virtual env
 
-Create the virutal environment with `virtualenv` followed by the environment name, in this example: `tooling`
+Create the virtual environment with `virtualenv` followed by the environment name, in this example: `tooling`
 
 ```
 virtualenv tooling
@@ -46,10 +46,7 @@ To instantiate the generator and its dependencies:
 
 
 
-## Setup (to be depcrecated)
+## Setup (to be deprecated)
 
 To instantiate the generator and its dependencies, run
 `sudo python setup.py install`
-
-
-

--- a/tools/scoring/README.md
+++ b/tools/scoring/README.md
@@ -14,7 +14,7 @@ To install please follow the instructions below.
 
 ### First create a virtual env
 
-Create the virutal environment with `virtualenv` followed by the environment name, in this example: `tooling`
+Create the virtual environment with `virtualenv` followed by the environment name, in this example: `tooling`
 
 ```
 virtualenv tooling

--- a/tools/validators/instance_validator/README.md
+++ b/tools/validators/instance_validator/README.md
@@ -15,7 +15,7 @@ You can run the command with just the version flag (e.g. `python --version`) to 
 
 ### First create a virtual env
 
-Create the virutal environment with `virtualenv` followed by the environment name, in this example: `tooling`
+Create the virtual environment with `virtualenv` followed by the environment name, in this example: `tooling`
 
 ```
 virtualenv tooling
@@ -69,7 +69,7 @@ Note: as of the current development stage, you must clone the entire repository 
 The validator supports a telemetry validation mode. When this mode is enabled, the validator will listen on a provided pubsub subscription for telemetry messages, and validate the message contents against the instance configuration. It is recommended that you first use the instance validator with telemetry validation mode disabled, and then enable it after that passes.
 
 If you would like to use the telemetry validation mode, you must provide the `--subscription` parameter, and you must either:
-- Have the both the `gcloud` CLI installed and configured using `gcloud init` using an appropiate project, and [`gcloud application-default` credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default) setup with an account which has adequate permissions to access the given subscription
+- Have the both the `gcloud` CLI installed and configured using `gcloud init` using an appropriate project, and [`gcloud application-default` credentials](https://cloud.google.com/sdk/gcloud/reference/auth/application-default) setup with an account which has adequate permissions to access the given subscription
 - Provide a `--service-account` parameter when running instance_validator.py. Failure to provide both of these parameters will result in early termination of the validator and an error message. If you do not provide either parameter, the validator will run with telemetry validation mode disabled.
 
 **NOTE** The service account key and subscription are provided by the Google team. Please reach out to your IoT TPM for guidance.
@@ -137,7 +137,7 @@ validation logic and cause the validator to exit prematurely because the instanc
               degrees_celsius: "degC"
               degrees_fahrenheit: "degF"
 
-**Warnings** on the other hand expose inconsistencies in the content of an entity block but do not cause the validator to fail since the core elements of what make an entity block readable are still present. For example, if the fields defined in `translation` or `links` do not align with the fields for the entity's type as defined in [Digital Builings Ontology](https://github.com/google/digitalbuildings/tree/master/ontology/yaml), then the validator will warn the user it is not a valid entity.
+**Warnings** on the other hand expose inconsistencies in the content of an entity block but do not cause the validator to fail since the core elements of what make an entity block readable are still present. For example, if the fields defined in `translation` or `links` do not align with the fields for the entity's type as defined in [Digital Buildings Ontology](https://github.com/google/digitalbuildings/tree/master/ontology/yaml), then the validator will warn the user it is not a valid entity.
 
     The following entity block would only expose a warning because these are not the fields for VAV_SD_DSP as defined in DBO:
 

--- a/tools/validators/ontology_validator/README.md
+++ b/tools/validators/ontology_validator/README.md
@@ -1,12 +1,12 @@
 # Validator
 
-The Ontology Validator allows you to extend the ontology and then validate it to make sure it is comform to guidelines.
+The Ontology Validator allows you to extend the ontology and then validate it to make sure it is conform to guidelines.
 
 ## Install requirements
 
 ### First create a virtual env
 
-Create the virutal environment with `virtualenv` followed by the environment name, in this example: `tooling`
+Create the virtual environment with `virtualenv` followed by the environment name, in this example: `tooling`
 
 ```
 virtualenv tooling


### PR DESCRIPTION
This fixes a few typos and a small amount of grammar errors I noticed in the repo. It also fixes the LICENSE file to ensure that it follows the standard format expected by most projects.