### PR TITLE
added fan abstract and canonical types

### DIFF
--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -6606,3 +6606,16 @@ VMADC:
   - mixed_air_damper_percentage_sensor
   implements:
   - CONTROL
+
+
+DSPZTM:
+  description: "idf room fan with monitoring and high, low alarm setpoints"
+  is_abstract: true
+  uses:
+  - high_limit_zone_air_temperature_setpoint
+  - low_limit_zone_air_temperature_setpoint
+  - Zone_air_temperature_sensor
+  - high_zone_air_temperature_alarm
+  - low_zone_air_temperature_alarm
+  - failed_zone_air_temperature_alarm
+  - failed_alarm

--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -6614,7 +6614,7 @@ DSPZTM:
   uses:
   - high_limit_zone_air_temperature_setpoint
   - low_limit_zone_air_temperature_setpoint
-  - Zone_air_temperature_sensor
+  - zone_air_temperature_sensor
   - high_zone_air_temperature_alarm
   - low_zone_air_temperature_alarm
   - failed_zone_air_temperature_alarm

--- a/ontology/yaml/resources/HVAC/entity_types/FAN.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/FAN.yaml
@@ -737,3 +737,10 @@ FAN_SS_MSM:
   implements:
   - FAN
   - MSM
+
+FAN_DSPZTM:
+  description: "idf room fan with monitoring and high, low alarm setpoints"
+  is_canonical: true
+  implements:
+  - FAN
+  - DSZTM

--- a/ontology/yaml/resources/HVAC/entity_types/FAN.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/FAN.yaml
@@ -743,4 +743,4 @@ FAN_DSPZTM:
   is_canonical: true
   implements:
   - FAN
-  - DSZTM
+  - DSPZTM

--- a/ontology/yaml/resources/fields/telemetry_fields.yaml
+++ b/ontology/yaml/resources/fields/telemetry_fields.yaml
@@ -3102,3 +3102,11 @@ literals:
 - ultraviolet_irradiance_sensor:
     fixed_min: 0.0
     flexible_max: 2000.0
+
+- high_limit_zone_air_temperature_setpoint:
+    fixed_min: 255.9259259
+    flexible_max: 338.7037037
+
+- low_limit_zone_air_temperature_setpoint:
+    fixed_min: 255.9259259
+    flexible_max: 338.7037037


### PR DESCRIPTION
Not sure the best way to model this, in the idf room, there are 3 units with failed alarm triggered if any of them fail, and the rest of the points relate to the entire room rather than the individual units.