### PR TITLE
Revert abel readme

### DIFF
--- a/tools/abel/README.md
+++ b/tools/abel/README.md
@@ -170,3 +170,14 @@ python3 abel.py -s <input_spreadsheet_id> -c <path/to/client_credential.json> -d
    to the same directory with names:
    * `bc_export_<today_date_and_time>.yaml`
    * `instance_validation_<today_date_and_time>.log`
+
+### Split Functionality
+To split a building config file on a certain namespace:
+
+1. Run abel with a json credential and a building config:
+    ```
+    python3 abel.py -c /path/to/credential.json -b absolute/path/to/building/config
+    ```
+2. Select option 3: `Split a building config`
+3. ABEL will generate a new building config split on the desired namespace
+   along with any dependencies. Provide the `-d` argument if you would like ABEL to write to a specific directory.

--- a/tools/abel/README.md
+++ b/tools/abel/README.md
@@ -82,8 +82,10 @@ cd abel
 
 ## Using ABEL
 ABEL has a few pieces of core functionality, they are:
-* Ingest an [ABEL spreadsheet](../../tools/abel/validators/README.md) and export a valid [Building Config](../../ontology/docs/building_config.md) file
-* Ingest a [Building Config](../../ontology/docs/building_config.md) and export an [ABEL spreadsheet](../../tools/abel/validators/README.md)
+1. Modify a spreadsheet or a building config for an existing building to produce an [UPDATE building config](../../ontology/docs/building_config.md#update)
+  * [Update Workflow](#update-workflow)
+2. Create a [Building Config](../../ontology/docs/building_config.md) from an [ABEL spreadsheet](../../tools/abel/validators/README.md) for a new building 
+  * [Initialization workflow](#initialization-workflow)
 
 ### Command-line arguments for ABEL:
 `-c` or `--credential` absolute or relative path to a gcp OAuth client
@@ -95,7 +97,7 @@ against Google Sheets service.
   * A Google Sheets ID is found embedded into the spreadsheet's url. Required when ABEL is creating a building config from a Google spreadsheet.
   e.g. `https://docs/google/com/spreadsheets/d/<spreadsheet_id>/edit#gid=123467`
 
-`-b` or `--building_config` absolute path to a local building configuration
+`-b` or `--building_config` absolute o relative path to a local building configuration
 file. Only required for the `Building Config -> Spreadsheet` workflow.
   * [Building Configuration Docs](../../ontology/docs/building_config.md)
 
@@ -118,9 +120,39 @@ Config](../../ontology/docs/building_config.md).
 
 Please see the [ABEL spreadsheet docs](../../tools/abel/validators/README.md) for detailed instructions on how to create your own spreadsheet.
 
-### Spreadsheet -> Building Config
+### Update Workflow
 
-The process for using an ABEL spreadsheet to generate a Building Config is as
+If you would like to create a building config to update an already onboarded building, then there are two options:
+1. Update an exported building config.
+
+  The process for using a building config to generate an ABEL spreadsheet is as
+  follows:
+
+  1. In `digitalbuildings/tools/abel` run ABEL with the command:
+  ```
+  python3 abel.py -c /path/to/credential.json -b absolute/path/to/building/config
+  ```
+
+2. Generate a building config from an already updated spreadsheet.
+
+  1. In `digitalbuildings/tools/abel` run ABEL with the command:
+  ```
+  python3 abel.py -s <input_spreadsheet_id> -c <path/to/client_credential.json> -d <path/to/output/directory>
+  ```
+  2. If your spreadsheet does not pass the validation criteria found in the
+    [spreadsheet docs](../../tools/abel/validators/README.md) then ABEL will fast
+    fail and a validation
+    report will be created in your current directory with the name,
+    `spreadsheet_validation_<todays_date_and_time>.log`
+  3. The resulting Building Config and instance validation report will be written
+    to the current directory with names:
+    * `bc_export_<today_date_and_time>.yaml`
+    * `instance_validation_<today_date_and_time>.log`
+
+### Initialization workflow
+If you would like create a building configuration file under the initialization operation
+
+The process for using an ABEL spreadsheet to generate a new Building Config is as
 follows:
 
 1. Create a spreadsheet for ABEL from [ABEL Spreadsheet template](https://docs.google.com/spreadsheets/d/1tcLjFnHiXUT-xh5C1hRKiUVaUH_CzgSI8zFQ_B8q7vs/copy#gid=980240783)
@@ -128,7 +160,7 @@ follows:
    spreadsheet can be found in the [spreadsheet docs](../../tools/abel/validators/README.md)
 3. In `digitalbuildings/tools/abel` run ABEL with the command:
 ```
-python3 abel.py -c <path/to/credential.json> -s <input_spreadsheet_id>
+python3 abel.py -s <input_spreadsheet_id> -c <path/to/client_credential.json> -d <path/to/output/directory>
 ```
 4. If your spreadsheet does not pass the validation criteria found in the
    [spreadsheet docs](../../tools/abel/validators/README.md) then ABEL will fast
@@ -138,13 +170,3 @@ python3 abel.py -c <path/to/credential.json> -s <input_spreadsheet_id>
    to the same directory with names:
    * `bc_export_<today_date_and_time>.yaml`
    * `instance_validation_<today_date_and_time>.log`
-
-### Building Config -> Spreadsheet
-
-The process for generating an ABEL spreadsheet from a building config is as
-follows:
-
-1. In `digitalbuildings/tools/abel` run ABEL with the command:
-```
-python3 abel.py -c /path/to/credential.json -b absolute/path/to/building/config
-```

--- a/tools/abel/README.md
+++ b/tools/abel/README.md
@@ -18,10 +18,11 @@ Total setup process should only take about 15 minutes.
 Before starting the setup and installation process, please ensure that the
 dependencies are met:
 1. You are running **Python 3.9** or higher
-3. You have installed [virtualenv](https://pypi.org/project/virtualenv/)
 2. you have installed the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)
 
 ### Set up a tooling environment
+
+If environment is already set up then the following steps can be ignored.
 
 1. Clone the Digital Buildings repository
 
@@ -59,7 +60,7 @@ dependencies are met:
 
 * Linux/MacOs:
   ```
-  bash pip_install.sh
+  ./pip_install.sh
   ```
 
 * Windows:
@@ -111,7 +112,7 @@ Validator](../validators/ontology_validator) will surface validation results
 from the modified ontology, and Building Configuration files will be validated
 against the modified ontology.
 
-`-d` or `--output-dir` fully qualified or relative file path to a directory which ABEL can write validation logs to. ABEL must have write access to this directory or else an error will be raised.
+`-d` or `--output-dir` fully qualified or relative file path to a directory which ABEL can write files to. ABEL must have write access to this directory or else an error will be raised.
 
 ### The ABEL Spreadsheet
 The ABEL spreadsheet serves as a user-friendly interface for ABEL and is what
@@ -176,7 +177,7 @@ To split a building config file on a certain namespace:
 
 1. Run abel with a json credential and a building config:
     ```
-    python3 abel.py -c /path/to/credential.json -b absolute/path/to/building/config
+    python3 abel.py -c </path/to/credential.json> -b </path/to/building/config>
     ```
 2. Select option 3: `Split a building config`
 3. ABEL will generate a new building config split on the desired namespace

--- a/tools/abel/README.md
+++ b/tools/abel/README.md
@@ -87,6 +87,8 @@ ABEL has a few pieces of core functionality, they are:
   * [Update Workflow](#update-workflow)
 2. Create a [Building Config](../../ontology/docs/building_config.md) from an [ABEL spreadsheet](../../tools/abel/validators/README.md) for a new building 
   * [Initialization workflow](#initialization-workflow)
+3. Split a building configuration file on a namespace
+  * [Split Workflow](#split-functionality)
 
 ### Command-line arguments for ABEL:
 `-c` or `--credential` absolute or relative path to a gcp OAuth client


### PR DESCRIPTION
The ABEL README.md was overwritten and reverted to an earlier version. This PR reverts the overwrite and adds documentation on how to use the split functionality.