### PR TITLE
Added UPS type and subtype for battery remaining time

### DIFF
--- a/ontology/yaml/resources/ELECTRICAL/entity_types/UPS.yaml
+++ b/ontology/yaml/resources/ELECTRICAL/entity_types/UPS.yaml
@@ -14,7 +14,7 @@
 
 UPS_SS:
   guid: "70d8719e-db43-4f6f-b44f-7047a4c30a26"
-  description: "Standard UPS unit."
+  description: "Standard UPS unit with start stop."
   is_canonical: true
   implements:
   - UPS
@@ -83,3 +83,17 @@ UPS_SS_UPSBM:
   - UPS
   - SS
   - UPSBM
+  
+UPS_UPSBM:
+  guid: "19625580-f0d7-486e-a054-bb1eecd95b0a"
+  description: "Basic UPS with battery monitoring"
+  is_canonical: false
+  implements:
+  - UPS
+  uses:
+  - input_supply_mode
+  - battery_percentage_sensor
+  opt_uses:
+  - remaining_battery_time_sensor
+  - load_percentage_sensor
+  - output_apparent_power_sensor

--- a/ontology/yaml/resources/fields/telemetry_fields.yaml
+++ b/ontology/yaml/resources/fields/telemetry_fields.yaml
@@ -2848,7 +2848,9 @@ literals:
 - battery_percentage_sensor:
     fixed_min: 0.0
     fixed_max: 100.0
-
+- remaining_battery_time_sensor:
+    fixed_min: 0.0
+    flexible_max: 1440.0
 - dc_voltage_sensor:
     flexible_min: 0.0
     flexible_max: 500.0


### PR DESCRIPTION
Added an entity type UPS_UPSBM, also added a field to the ELECTRICAL namespace to support UPS battery remaining time.