### PR TITLE
Remove ambiguous gallons_per_minute

### DIFF
--- a/ontology/yaml/resources/units/units.yaml
+++ b/ontology/yaml/resources/units/units.yaml
@@ -200,9 +200,6 @@ flowrate:
   liters_per_hour:
     multiplier: 0.000000277777777778
     offset: 0
-  gallons_per_minute:
-    multiplier: 0.0000630901964
-    offset: 0
   imperial_gallons_per_minute:
     multiplier: 0.000075768166666667
     offset: 0


### PR DESCRIPTION
We already have us_gallons and imperial_gallons, so having an undescribed gallons is confusing

Setting up in a standalone PR as this is potentially disruptive due to lack of backwards compatability