### PR TITLE
Removing per_second/minute/hour

### DIFF
--- a/ontology/yaml/resources/units/units.yaml
+++ b/ontology/yaml/resources/units/units.yaml
@@ -225,15 +225,6 @@ frequency:
   megahertz:
     multiplier: 0.000001
     offset: 0
-  per_hour:
-    multiplier: 3600
-    offset: 0
-  per_minute:
-    multiplier: 60
-    offset: 0
-  per_second:
-    multiplier: 1
-    offset: 0
 humidity:
   percent_relative_humidity: STANDARD
 illuminance:


### PR DESCRIPTION
They're redundant with hertz, cycles_per_minute/hour

Setting up in a standalone PR as this is potentially disruptive due to lack of backwards compatability