### PR TITLE
Migrating shade_orientation_specification to shade_orientation_mode

### DIFF
--- a/ontology/yaml/resources/HVAC/entity_types/SDC.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/SDC.yaml
@@ -83,7 +83,7 @@ SDC_EXTOR:
   - SDC
   - EXTOR
   opt_uses:
-  - shade_orientation_specification
+  - shade_orientation_mode
   - shade_mode
 
 SDC_UDEC:

--- a/ontology/yaml/resources/fields/telemetry_fields.yaml
+++ b/ontology/yaml/resources/fields/telemetry_fields.yaml
@@ -3100,7 +3100,7 @@ literals:
 - outside_illuminance_sensor:
     flexible_min: 0.0
     flexible_max: 5000.0
-- shade_orientation_specification:
+- shade_orientation_mode:
   - NORTH
   - SOUTH
   - EAST


### PR DESCRIPTION
Specification is an illegal point type as they made only have numeric values. Should be something that supports a Multi-state, like mode

Setting up in a standalone PR as this is potentially disruptive due to lack of backwards compatability