### PR TITLE
Removing Mass Ratio of Water to Dry Matter units from concentration

### DIFF
--- a/ontology/yaml/resources/units/units.yaml
+++ b/ontology/yaml/resources/units/units.yaml
@@ -60,12 +60,6 @@ concentration:
   parts_per_billion:
     multiplier: 0.000000001
     offset: 0
-  grams_per_kilogram: # Can convert approximately using Avogadro
-    multiplier: 0.001
-    offset: 0
-  grams_of_water_per_kilogram:
-    multiplier: 0.001
-    offset: 0
 current:
   amperes: STANDARD
   milliamperes:


### PR DESCRIPTION
While these units are types of concentration, they're conditional to the medium of the dry matter in order to do conversions from the standard unit of parts:parts. So removing while they're unused. If we want to reintroduce them, we should ensure that it belongs under concentration as opposed to redefining massconcentration

This change is not fully backwards compatible so will need land with grace.