### PR TITLE
add non-canonical landlord AHU type

### DIFF
--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -5355,7 +5355,7 @@ AHU_NON_CANONICAL_TYPE_71:
   - supply_air_flowrate_sensor
   
 AHU_SFSS_NON_CANONICAL_72:
-  description: “Landlord system that only receives status/command and alarm”
+  description: "Landlord system that only receives status/command and alarm"
   implements:
   - AHU
   - SFSS

--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -5355,6 +5355,7 @@ AHU_NON_CANONICAL_TYPE_71:
   - supply_air_flowrate_sensor
   
 AHU_SFSS_NON_CANONICAL_72:
+  guid: "3473e1f2-390c-401f-ae2d-b2cdeb575fdd"
   description: "Landlord system that only receives status/command and alarm"
   implements:
   - AHU

--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -5355,7 +5355,6 @@ AHU_NON_CANONICAL_TYPE_71:
   - supply_air_flowrate_sensor
   
 AHU_SFSS_NON_CANONICAL_72:
-  guid: "49919b5f-0bd3-4ab6-b846-a5fbaaca236c"
   description: “Landlord system that only receives status/command and alarm”
   implements:
   - AHU

--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -5353,7 +5353,16 @@ AHU_NON_CANONICAL_TYPE_71:
   - supply_fan_speed_frequency_sensor
   - supply_fan_speed_percentage_command
   - supply_air_flowrate_sensor
-
+  
+AHU_SFSS_NON_CANONICAL_72:
+  guid: "49919b5f-0bd3-4ab6-b846-a5fbaaca236c"
+  description: “Landlord system that only receives status/command and alarm”
+  implements:
+  - AHU
+  - SFSS
+  opt_uses:
+  - lost_power_alarm
+      
 AHU_STDSPC_SSPC_EFFC_EFVSC_FDPM3X_HTWHLSTC_RHM_ETM:
   guid: "dbe00902-c2da-4efd-b8f2-2069ddd674c3"
   description: "Non-Standard (Swegon) Multi-Zone AHU with heat wheel, isolation damper and filter pressure monitoring"


### PR DESCRIPTION
Landlord AHU gave only 3 points status,control and lost power alarm. Was originally modelled from FAN_SS but that was in error, this is now modelled using AHU non canonical type.