### PR TITLE
Project import generated by Copybara.

### DIFF
--- a/tools/toolkit.py
+++ b/tools/toolkit.py
@@ -71,9 +71,10 @@ def _ParseArgs() -> argparse.ArgumentParser:
       '--modified-ontology-types',
       dest='modified_types_filepath',
       required=False,
-      default=DEFAULT_ONTOLOGY_PATH,
+      default=None,
       help='Filepath to modified type filepaths',
-      metavar='MODIFIED_TYPE_FILEPATHS')
+      metavar='MODIFIED_TYPE_FILEPATHS',
+  )
 
   parser.add_argument(
       '-s',
@@ -132,6 +133,7 @@ if __name__ == '__main__':
     handler.RunValidation(
         filenames=args.filenames,
         modified_types_filepath=args.modified_types_filepath,
+        default_types_filepath=DEFAULT_ONTOLOGY_PATH,
         subscription=args.subscription,
         gcp_credential_path=args.gcp_credential,
         report_directory=args.report_directory,

--- a/tools/validators/instance_validator/instance_validator.py
+++ b/tools/validators/instance_validator/instance_validator.py
@@ -91,8 +91,9 @@ def _ParseArgs() -> argparse.ArgumentParser:
       '--udmi',
       dest='udmi',
       required=False,
-      default='True',
-      help='Parse messages as UDMI')
+      default='False',
+      help='Parse messages as UDMI',
+  )
 
   return parser
 

--- a/tools/validators/instance_validator/validate/generate_universe.py
+++ b/tools/validators/instance_validator/validate/generate_universe.py
@@ -43,6 +43,7 @@ def BuildUniverse(
     Generated universe object.
   """
   if use_simplified_universe:
+    print('Using simplified universe for testing purposes.')
     yaml_files = None
     universe = universe_helper.create_simplified_universe()
   elif modified_types_filepath:
@@ -55,6 +56,7 @@ def BuildUniverse(
       return None
 
     modified_types_filepath = path.expanduser(modified_types_filepath)
+    print(f'Validating modified universe from [{modified_types_filepath}]...')
 
     external_file_lib.Validate(
         filter_text=None,
@@ -62,6 +64,7 @@ def BuildUniverse(
         original_directory=default_types_filepath,
         interactive=False,
     )
+    print(f'Using modified universe from [{modified_types_filepath}].')
     yaml_files = external_file_lib.RecursiveDirWalk(modified_types_filepath)
   else:
     if default_types_filepath is None:
@@ -73,7 +76,7 @@ def BuildUniverse(
           'default ontology does not exist.'
       )
       return None
-    # use default location for ontology files
+    print(f'Using default universe from [{default_types_filepath}].')
     yaml_files = external_file_lib.RecursiveDirWalk(default_types_filepath)
 
   if yaml_files:


### PR DESCRIPTION
PiperOrigin-RevId: 695777455

Improve default parameters and output for universe selection and UDMI in toolkit and instance_validator.

Details of changes:
- Aligned udmi default parameter in instance_validator to toolkit default: False
- Ensure toolkit correctly uses "default types path" instead of "modified types path" if no ontology changes are set. This ensures instance validator can skip the lengthy validation step when it isn't needed
- Also added some output to make it clear which universe got selected and that validation is running if a modified universe gets selected
