### PR TITLE
Temporary Validator Updates

### DIFF
--- a/tools/validators/ontology_validator/yamlformat/validator/field_lib.py
+++ b/tools/validators/ontology_validator/yamlformat/validator/field_lib.py
@@ -667,7 +667,10 @@ class Field(findings_lib.Findings):
     if self.name == 'scene_index_command':
       return True
     if 'command' in self.subfields and not (
-        'percentage_command' in self.name or 'frequency_command' in self.name):
+        'percentage_command' in self.name or 'frequency_command' in self.name or 'voltage_command' in self.name):
+      return False
+    if 'specification' in self.subfields and (
+        'orientation_specification' in self.name):
       return False
     if has_measurement_subfield:
       return True

--- a/tools/validators/ontology_validator/yamlformat/validator/field_lib.py
+++ b/tools/validators/ontology_validator/yamlformat/validator/field_lib.py
@@ -667,8 +667,9 @@ class Field(findings_lib.Findings):
     if self.name == 'scene_index_command':
       return True
     if 'command' in self.subfields and not (
-        'percentage_command' in self.name or 'frequency_command' in self.name 
-        or 'voltage_command' in self.name):
+        'percentage_command' in self.name or 
+        'frequency_command' in self.name or 
+        'voltage_command' in self.name):
       return False
     if 'specification' in self.subfields and (
         'orientation_specification' in self.name):

--- a/tools/validators/ontology_validator/yamlformat/validator/field_lib.py
+++ b/tools/validators/ontology_validator/yamlformat/validator/field_lib.py
@@ -667,7 +667,8 @@ class Field(findings_lib.Findings):
     if self.name == 'scene_index_command':
       return True
     if 'command' in self.subfields and not (
-        'percentage_command' in self.name or 'frequency_command' in self.name or 'voltage_command' in self.name):
+        'percentage_command' in self.name or 'frequency_command' in self.name 
+        or 'voltage_command' in self.name):
       return False
     if 'specification' in self.subfields and (
         'orientation_specification' in self.name):


### PR DESCRIPTION
Added some updates to the ontology validator as a temporary solution to allow some outstanding PRs to merge. Carson team to eventually rewrite this section to avoid the need to call out specific subfields.