### PR TITLE
Fixing badge icon link on main Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Tools](https://github.com/google/digitalbuildings/actions/workflows/tools.yml/badge.svg)](https://github.com/google/digitalbuildings/actions/workflows/tools.yml)
-![Ontology Type Validator](https://github.com/google/digitalbuildings/workflows/Ontology%20Type%20Validator/badge.svg)
+![Ontology Validator](https://github.com/google/digitalbuildings/actions/workflows/OntologyValidator.yml/badge.svg)
 ![Node.js CI](https://github.com/google/digitalbuildings/workflows/Node.js%20CI/badge.svg)
 [![GitHub stars](https://img.shields.io/github/stars/google/digitalbuildings.svg)](https://github.com/google/digitalbuildings/stargazers)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
Icon is also rendered broken on https://google.github.io/digitalbuildings/
Old one gives 404