### PR TITLE
Remove extra field from DMP_ED

### DIFF
--- a/ontology/yaml/resources/HVAC/entity_types/DMP.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/DMP.yaml
@@ -43,8 +43,6 @@ DMP_ED:
   guid: "f94434b4-3b01-4a69-a31c-9cc6e1afbc64"
   description: "Exhaust control damper."
   is_canonical: true
-  uses:
-  - exhaust_air_static_pressure_sensor
   implements:
   - DMP
   - ED


### PR DESCRIPTION
Remove exhaust_air_static_pressure_sensor from the uses on DMP_ED as it is already an opt_use on the ED abstract 