### PR TITLE
Include display_name in update_mask when its modified

### DIFF
--- a/tools/abel/model/from_spreadsheet.py
+++ b/tools/abel/model/from_spreadsheet.py
@@ -75,8 +75,7 @@ def LoadFieldsFromSpreadsheet(
     entity_field_entries: List[Dict[str, str]],
     guid_to_entity_map: GuidToEntityMap,
 ) -> List[FieldTranslation]:
-  """Loads list of entity fields from a spreadsheet into FieldTranslation
-  instances.
+  """Loads a list of entity fields into FieldTranslation instances.
 
   Once the entity field mapping is loaded into an FieldTranslation instance,
   it is then added to the ABEL internal model.

--- a/tools/abel/model/model_helper.py
+++ b/tools/abel/model/model_helper.py
@@ -62,13 +62,12 @@ def DetermineReportingEntityUpdateMask(
     updated_entity: An Entity instance from an updated building config.
   """
   update_mask = set()
-  # updated entity code
   if updated_entity.code != current_entity.code:
     update_mask.add(entity_enumerations.EntityUpdateMaskAttribute.CODE)
-  # updated entity type name
+  if (updated_entity.display_name or '') != (current_entity.display_name or ''):
+    update_mask.add(entity_enumerations.EntityUpdateMaskAttribute.DISPLAY_NAME)
   if updated_entity.type_name != current_entity.type_name:
     update_mask.add(entity_enumerations.EntityUpdateMaskAttribute.TYPE)
-  # updated entity connections
   if set(updated_entity.connections).difference(
       set(current_entity.connections)
   ):
@@ -138,6 +137,8 @@ def DetermineVirtualEntityUpdateMask(current_entity, updated_entity):
   update_mask = set()
   if updated_entity.code != current_entity.code:
     update_mask.add(entity_enumerations.EntityUpdateMaskAttribute.CODE)
+  if (updated_entity.display_name or '') != (current_entity.display_name or ''):
+    update_mask.add(entity_enumerations.EntityUpdateMaskAttribute.DISPLAY_NAME)
   if updated_entity.type_name != current_entity.type_name:
     update_mask.add(entity_enumerations.EntityUpdateMaskAttribute.TYPE)
   if set(updated_entity.connections).difference(

--- a/tools/abel/tests/model_helper_test.py
+++ b/tools/abel/tests/model_helper_test.py
@@ -193,6 +193,7 @@ class ModelHelperTest(absltest.TestCase):
         EntityUpdateMaskAttribute.TYPE,
         EntityUpdateMaskAttribute.CONNECTIONS,
         EntityUpdateMaskAttribute.LINKS,
+        EntityUpdateMaskAttribute.DISPLAY_NAME,
     }
 
     actual_updated_mask = model_helper.DetermineVirtualEntityUpdateMask(


### PR DESCRIPTION
1. Added changes to include `display_name` in the `update_mask` when it is modified.  
2. Fixed a formatting issue which was getting flagged in g3. 