### PR TITLE
Fix: Ensure update_mask uses lowercase values in Building Config export

### DIFF
--- a/tools/abel/model/export_helper.py
+++ b/tools/abel/model/export_helper.py
@@ -230,7 +230,7 @@ class BuildingConfigExport(object):
       update_dict = {}
     if operation.update_mask:
       update_dict.update(
-          {'update_mask': [x.name for x in operation.update_mask]}
+          {'update_mask': [x.value for x in operation.update_mask]}
       )
     return update_dict
 

--- a/tools/abel/tests/export_helper_test.py
+++ b/tools/abel/tests/export_helper_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for Export Helper."""
 
+import copy
 import os
 import tempfile
 
@@ -25,6 +26,9 @@ from model import import_helper
 from model.constants import ENTITY_FIELDS
 from model.constants import SHEETS
 from model.constants import V4
+from model.entity_enumerations import EntityOperationType
+from model.entity_enumerations import EntityUpdateMaskAttribute
+from model.entity_operation import EntityOperation
 from model.export_helper import BuildingConfigExport
 from model.export_helper import GoogleSheetExport
 from model.model_builder import Model
@@ -48,7 +52,7 @@ class ExportHelperTest(absltest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.input_spreadsheet = TEST_SPREADSHEET.copy()
+    self.input_spreadsheet = copy.deepcopy(TEST_SPREADSHEET)
 
     self.export_filepath = os.path.join(
         tempfile.gettempdir(), 'exported_building_config.yaml'
@@ -248,12 +252,12 @@ class ExportHelperTest(absltest.TestCase):
     )
 
   def testExportBuildingConfigRaisesValueErrorForBadMultistate(self):
-    bad_input_spreadsheet = TEST_SPREADSHEET.copy()
+    bad_input_spreadsheet = copy.deepcopy(TEST_SPREADSHEET)
     bad_input_spreadsheet[ENTITY_FIELDS].append(
         TEST_BAD_MULTISTATE_FIELD_DICT_NO_STATES
     )
     unbuilt_model, operations = Model.Builder.FromSpreadsheet(
-        self.input_spreadsheet
+        bad_input_spreadsheet
     )
     model = unbuilt_model.Build()
     export_helper = BuildingConfigExport(model)
@@ -261,6 +265,40 @@ class ExportHelperTest(absltest.TestCase):
     with self.assertRaises(ValueError):
       export_helper.ExportInitBuildingConfiguration(self.export_filepath)
 
+  def testExportBuildingConfigExportsUpdateMasksCorrectly(self):
+    operations = []
+    update_masks = list(EntityUpdateMaskAttribute)
+    for entity_guid in self.export_helper.model.site.entities:
+      entity = self.export_helper.model.guid_to_entity_map.GetEntityByGuid(
+          entity_guid
+      )
+      operations.append(
+          EntityOperation(
+              entity=entity,
+              operation=EntityOperationType.UPDATE,
+              update_mask=update_masks,
+          )
+      )
+
+    exported_updated_building_config = (
+        self.export_helper.ExportUpdateBuildingConfiguration(
+            self.export_filepath, operations
+        )
+    )
+
+    print(exported_updated_building_config)
+
+    expected_update_masks = [mask.value for mask in update_masks]
+    for entity_guid in self.export_helper.model.site.entities:
+      entity = self.export_helper.model.guid_to_entity_map.GetEntityByGuid(
+          entity_guid
+      )
+      entity_block = exported_updated_building_config.get(entity.bc_guid)
+      self.assertIsNotNone(entity_block)
+      self.assertEqual(entity_block.get('operation'), 'UPDATE')
+      self.assertCountEqual(
+          entity_block.get('update_mask'), expected_update_masks
+      )
 
 if __name__ == '__main__':
   absltest.main()

--- a/tools/abel/tests/export_helper_test.py
+++ b/tools/abel/tests/export_helper_test.py
@@ -286,8 +286,6 @@ class ExportHelperTest(absltest.TestCase):
         )
     )
 
-    print(exported_updated_building_config)
-
     expected_update_masks = [mask.value for mask in update_masks]
     for entity_guid in self.export_helper.model.site.entities:
       entity = self.export_helper.model.guid_to_entity_map.GetEntityByGuid(


### PR DESCRIPTION
Bug - 447591799

When exporting a Building Configuration with the 'UPDATE' operation, the `update_mask` list contained uppercase enum names (e.g., 'CODE', 'LINKS') instead of the required lowercase field names (e.g., 'code', 'links'). This was caused by iterating over the
`EntityUpdateMaskAttribute` enum and using the member `.name` instead of its `.value`.

This change modifies `_AddOperationToBlock` in `export_helper.py` to use `mask.value` when constructing the `update_mask` list, ensuring the exported values are lowercase, as required by the Building Config schema.

In addition, the following improvements were made to the test suite:
- Added `testExportBuildingConfigExportsUpdateMasksCorrectly` to verify `update_mask` values are exported in lowercase.
- Replaced `dict.copy()` with `copy.deepcopy()` for `TEST_SPREADSHEET` in `export_helper_test.py` to fix test isolation issues and prevent state leakage between tests.
- Fixed `testExportBuildingConfigRaisesValueErrorForBadMultistate` to use the correct input data (`bad_input_spreadsheet`) after changing it to deepcopy. This prevents state leakage between tests.

Validations:
Validated the changes in //third_party on cider. All tests passed.