### PR TITLE
Optimal Control Type Updates

### DIFF
--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -44,6 +44,8 @@ SD:
   - flowrate_requirement
   - unoccupied_flowrate_requirement
   - user_occupancy_override_status
+  - emergency_stop_alarm
+  - occupancy_status
   uses:
   - supply_air_damper_percentage_command
   - supply_air_flowrate_sensor
@@ -1157,6 +1159,7 @@ DFSS:
   - overload_discharge_fan_alarm
   - zone_occupancy_status
   - user_occupancy_override_status
+  - local_override_discharge_fan_alarm
   uses:
   - discharge_fan_run_command
   - discharge_fan_run_status
@@ -3032,6 +3035,7 @@ DXZC:
   - cooling_percentage_command
   - cooling_thermal_power_capacity
   - discharge_air_temperature_sensor
+  - local_override_compressor_alarm
   - leaving_cooling_coil_temperature_sensor
   - compressor_lost_power_alarm
   - failed_compressor_alarm
@@ -3219,6 +3223,9 @@ DX2SC:
   - compressor_speed_percentage_command
   - compressor_speed_percentage_command_1
   - compressor_speed_percentage_command_2
+  - failed_compressor_alarm_1
+  - failed_compressor_alarm_2
+  - failed_cooling_alarm
   - cooling_percentage_command
   - cooling_request_count
   - cooling_thermal_power_capacity
@@ -8672,6 +8679,7 @@ DAIDC:
   uses:
   - discharge_air_isolation_damper_command
   - discharge_air_isolation_damper_status
+  - local_override_discharge_air_isolation_damper_alarm
   implements:
   - MONITORING
   opt_uses:

--- a/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/ABSTRACT.yaml
@@ -1159,7 +1159,6 @@ DFSS:
   - overload_discharge_fan_alarm
   - zone_occupancy_status
   - user_occupancy_override_status
-  - local_override_discharge_fan_alarm
   uses:
   - discharge_fan_run_command
   - discharge_fan_run_status

--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -3991,6 +3991,22 @@ AHU_SS_SSPC_CHWVM_HWVM_STM_FDPM_OA:
   - FDPM
   - OA
 
+AHU_SS_SARC_BSPC_ECON_MTM_SFSS_SSPC_DX2SC_EFSS_EFVSC:
+  description: "AHU for preconditioning supply air"
+  is_canonical: true
+  implements:
+  - AHU
+  - SS
+  - SARC
+  - BSPC
+  - ECON
+  - MTM
+  - SFSS
+  - SSPC
+  - DX2SC
+  - EFSS
+  - EFVSC
+
 AHU_SS_SSPC_CHWVM_HWVM_STM_OA:
   guid: "b69a79eb-7900-4f95-922d-edbe4c51b1ab"
   description: "AHU for preconditioning supply air"

--- a/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/AHU.yaml
@@ -4008,6 +4008,7 @@ AHU_SS_SSPC_CHWVM_HWVM_STM_FDPM_OA:
   - OA
 
 AHU_SS_SARC_BSPC_ECON_MTM_SFSS_SSPC_DX2SC_EFSS_EFVSC:
+  guid: "d0c9cefe-3461-4dbd-8353-14175bba60ab"
   description: "AHU for preconditioning supply air"
   is_canonical: true
   implements:

--- a/ontology/yaml/resources/HVAC/entity_types/BLR.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/BLR.yaml
@@ -376,6 +376,7 @@ BLR_SS_SWTC_HTSWC_RWISOVPM_NONCANONICAL_1:
   - flue_gas_temperature_sensor
 
 BLR_SS_SWTC_NONCANONICAL_3:
+  guid: "6549af4c-b6dc-4847-aeee-0a6a3767b05f"
   description: "Non-standard type."
   implements:
   - BLR_SS_SWTC

--- a/ontology/yaml/resources/HVAC/entity_types/BLR.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/BLR.yaml
@@ -375,3 +375,15 @@ BLR_SS_SWTC_HTSWC_RWISOVPM_NONCANONICAL_1:
   uses:
   - flue_gas_temperature_sensor
 
+BLR_SS_SWTC_NONCANONICAL_3:
+  description: "Non-standard type."
+  implements:
+  - BLR_SS_SWTC
+  - INCOMPLETE
+  uses:
+  - circulation_pump_run_status
+  - heating_percentage_sensor
+  - high_gas_pressure_alarm
+  - low_flowrate_alarm
+  - low_gas_pressure_alarm
+  - master_alarm


### PR DESCRIPTION
Some updated types to cover new OC sites.

Note that boiler is non-canonical due to extra points that are fairly generic but not very common. Instead of polluting abstract type definitions with more optional fields, just adding them directly to the non-canonical type definition.